### PR TITLE
Rename "status" to "message" for `statusPurpose` feature.

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,13 @@ Used to temporarily prevent the acceptance of a <a>verifiable credential</a>.
 This status is reversible.
                       </td>
                     </tr>
+                    <tr>
+                      <td>`message`</td>
+                      <td>
+Used to convey an arbitrary message related to the status of the
+<a>verifiable credential</a>.
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </td>
@@ -501,12 +508,12 @@ This status is reversible.
                       </td>
                     </tr>
                     <tr>
-                      <td>`status`</td>
+                      <td>`message`</td>
                       <td>
 Used to indicate a status message associated with a <a>verifiable
 credential</a>. The status message descriptions MUST be defined in
-`credentialSubject.statusMessages`. `credentialSubject.size` MUST be defined
-with this `statusPurpose`.
+`credentialSubject.statusMessages`. `credentialSubject.size` MUST be specified
+when this `statusPurpose` value is used.
                       </td>
                     </tr>
                   </tbody>
@@ -745,10 +752,9 @@ Let |status| be the value at the position indicated by the
 |credentialIndex| times the |size| in the |bitstring|.
         </li>
         <li>
-For `statusPurpose` of `revocation` or `suspension`,
-return `true` if `status` is `1`, and return `false`
-if `status` has any other value.  For other `statusPurpose`,
-return the corresponding `value` of the `status`
+For `statusPurpose` of `revocation` or `suspension`, return `true` if |status|
+is `1`, and return `false` if |status| has any other value. If the
+`statusPurpose` is `message`, return the corresponding `message` of the `value`
 as indicated in the `statusMessages` array.
         </li>
       </ol>

--- a/index.html
+++ b/index.html
@@ -752,10 +752,22 @@ Let |status| be the value at the position indicated by the
 |credentialIndex| times the |size| in the |bitstring|.
         </li>
         <li>
-For `statusPurpose` of `revocation` or `suspension`, return `true` if |status|
-is `1`, and return `false` if |status| has any other value. If the
-`statusPurpose` is `message`, return the corresponding `message` of the `value`
-as indicated in the `statusMessages` array.
+        </li>
+Let |result| be an empty [=map=].
+        <li>
+Set the `status` key in |result| to |status|, and set the `purpose` key in
+|result| to the value of `statusPurpose`.
+        </li>
+        <li>
+If |status| is `0`, set the `valid` key in |result| to `true`; otherwise, set it to
+`false`.
+        </li>
+        <li>
+If the `statusPurpose` is `message`, set the `message` key in |result| to
+the corresponding `message` of the `value` as indicated in the `statusMessages` array.
+        </li>
+        <li>
+Return |result|.
         </li>
       </ol>
     </section>


### PR DESCRIPTION
This PR renames the awkwardly named "status" "statusPurpose" field to "message" since the "statusPurpose" is about conveying arbitrary messages to verifiers. This PR will close out issue #42 if merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/100.html" title="Last updated on Dec 29, 2023, 11:52 PM UTC (94fb1cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/100/843b1d6...94fb1cc.html" title="Last updated on Dec 29, 2023, 11:52 PM UTC (94fb1cc)">Diff</a>