### PR TITLE
Add note specifying that issuer might be different for status lists.

### DIFF
--- a/index.html
+++ b/index.html
@@ -757,9 +757,9 @@ as indicated in the `statusMessages` array.
 It is expected that a <a>verifier</a> will ensure that it trusts the issuer
 of a <a>verifiable credential</a>, as well as the issuer of the associated
 <a href="#bitstringstatuslistcredential">BitstringStatusListCredential</a>,
-before utilizing the information contained in either credential for further
+before using the information contained in either credential for further
 decision making purposes. Implementers are advised that the issuers of these
-credential might be different in use cases where the original issuer of the
+credential might differ, such as when the original issuer of the
 <a>verifiable credential</a> does not maintain a record of its validity.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -752,6 +752,18 @@ return the corresponding `value` of the `status`
 as indicated in the `statusMessages` array.
         </li>
       </ol>
+
+      <p class="note" title="Issuer validation is use case dependent">
+It is expected that a <a>verifier</a> will ensure that it trusts the issuer
+of a <a href="#bitstringstatuslistcredential">BitstringStatusListCredential</a>,
+as well as the issuer of the associated <a>verifiable credential</a>, before
+utilizing the information contained in either credential for further decision
+making purposes. Implementers are advised that the issuer of each credential
+might be different entities in use cases where the original issuer of the
+credential does not maintain whether or not that credential continues to be
+valid.
+      </p>
+
     </section>
 
     <section class="normative">

--- a/index.html
+++ b/index.html
@@ -755,13 +755,12 @@ as indicated in the `statusMessages` array.
 
       <p class="note" title="Issuer validation is use case dependent">
 It is expected that a <a>verifier</a> will ensure that it trusts the issuer
-of a <a href="#bitstringstatuslistcredential">BitstringStatusListCredential</a>,
-as well as the issuer of the associated <a>verifiable credential</a>, before
-utilizing the information contained in either credential for further decision
-making purposes. Implementers are advised that the issuer of each credential
-might be different in use cases where the original issuer of the
-credential does not maintain whether or not that credential continues to be
-valid.
+of a <a>verifiable credential</a>, as well as the issuer of the associated
+<a href="#bitstringstatuslistcredential">BitstringStatusListCredential</a>,
+before utilizing the information contained in either credential for further
+decision making purposes. Implementers are advised that the issuers of these
+credential might be different in use cases where the original issuer of the
+<a>verifiable credential</a> does not maintain a record of its validity.
       </p>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -759,7 +759,7 @@ of a <a href="#bitstringstatuslistcredential">BitstringStatusListCredential</a>,
 as well as the issuer of the associated <a>verifiable credential</a>, before
 utilizing the information contained in either credential for further decision
 making purposes. Implementers are advised that the issuer of each credential
-might be different entities in use cases where the original issuer of the
+might be different in use cases where the original issuer of the
 credential does not maintain whether or not that credential continues to be
 valid.
       </p>


### PR DESCRIPTION
This PR attempts to address issue #7 by stating that the issuer of the original VC and the issuer of the status list VC might not be the same entity.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/103.html" title="Last updated on Jan 13, 2024, 3:58 PM UTC (612b477)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/103/843b1d6...612b477.html" title="Last updated on Jan 13, 2024, 3:58 PM UTC (612b477)">Diff</a>