### PR TITLE
Throw RANGE_ERROR for indexes outside the length of a bitstring.

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,8 +742,8 @@ Generate a |revocation bitstring| by passing
         </li>
         <li>
 Let |status| be the value in the |bitstring| at the position indicated
-by the |credentialIndex| times the |size|. If the |credentialIndex|
-times the |size| is a value outside of the range of the |bitstring|, a
+by the |credentialIndex| multiplied by the |size|. If the |credentialIndex|
+multiplied by the |size| is a value outside of the range of the |bitstring|, a
 <a data-cite="VC-DATA-MODEL-2.0#RANGE_ERROR">RANGE_ERROR</a> MUST be
 raised.
         </li>

--- a/index.html
+++ b/index.html
@@ -742,7 +742,10 @@ Generate a |revocation bitstring| by passing
         </li>
         <li>
 Let |status| be the value at the position indicated by the
-|credentialIndex| times the |size| in the |bitstring|.
+|credentialIndex| times the |size| in the |bitstring|. If the |credentialIndex|
+is a value outside of the range of the |bitstring|, a
+<a data-cite="VC-DATA-MODEL-2.0#RANGE_ERROR">RANGE_ERROR</a> MUST be
+raised.
         </li>
         <li>
 For `statusPurpose` of `revocation` or `suspension`,

--- a/index.html
+++ b/index.html
@@ -741,9 +741,9 @@ Generate a |revocation bitstring| by passing
 <a href="#bitstring-expansion-algorithm">Bitstring Expansion Algorithm</a>.
         </li>
         <li>
-Let |status| be the value at the position indicated by the
-|credentialIndex| times the |size| in the |bitstring|. If the |credentialIndex|
-is a value outside of the range of the |bitstring|, a
+Let |status| be the value in the |bitstring| at the position indicated
+by the |credentialIndex| times the |size|. If the |credentialIndex|
+times the |size| is a value outside of the range of the |bitstring|, a
 <a data-cite="VC-DATA-MODEL-2.0#RANGE_ERROR">RANGE_ERROR</a> MUST be
 raised.
         </li>


### PR DESCRIPTION
This PR is an attempt to address issue #9 by updating the validation algorithm to throw a RANGE_ERROR for indexes that are outside the length of a bitstring.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/104.html" title="Last updated on Jan 2, 2024, 7:46 PM UTC (9177a99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/104/843b1d6...9177a99.html" title="Last updated on Jan 2, 2024, 7:46 PM UTC (9177a99)">Diff</a>