### PR TITLE
Add protocol statements related to pub/sub of status lists.

### DIFF
--- a/common.js
+++ b/common.js
@@ -83,6 +83,13 @@ var ccg = {
       status: 'CG-DRAFT',
       publisher: 'Credentials Community Group'
     },
+    'OHTTP': {
+      title: 'Oblivious HTTP ',
+      href: 'https://datatracker.ietf.org/doc/html/draft-ietf-ohai-ohttp',
+      authors: ['Martin Thomson', 'Christopher A. Wood'],
+      status: 'Working Group Draft',
+      publisher: 'IETF Oblivious HTTP Application Intermediation'
+    },
     'IPFS': {
       title: 'InterPlanetary File System (IPFS)',
       href: 'https://en.wikipedia.org/wiki/InterPlanetary_File_System',

--- a/index.html
+++ b/index.html
@@ -815,17 +815,26 @@ Return the |uncompressed bitstring|.
 
   </section>
 
-  <section class="informative">
+  <section class="normative">
     <h2>Media Types</h2>
+
     <p>
-  When dereferencing `statusListCredential`, the content type of the
-  `statusListCredential` might be any media type registered for the purpose of
-  expressing a verifiable credential with one or more proofs.
+When publishing status list information, issuers SHOULD publish the status list
+using an HTTPS URL and in a way that makes it not possible to correlate usage
+patterns related to the list. When retrieving status list information, verifiers
+SHOULD retrieve the status list over protocols that guard against access
+pattern correlation, such as Oblivious HTTP [[?OHTTP]].
+    </p>
+
+    <p>
+When dereferencing `statusListCredential`, the content type of the
+`statusListCredential` might be any media type registered for the purpose of
+expressing a verifiable credential with one or more proofs.
     </p>
     <p>
-  For example, a verifiable credential secured with Data Integrity Proofs might
-  have content type `application/vc+ld+json`, whereas a verifiable credential
-  secured with SD-JWT might have content-type `application/sd-jwt`.
+For example, a verifiable credential secured with Data Integrity Proofs might
+have content type `application/vc+ld+json`, whereas a verifiable credential
+secured with SD-JWT might have content-type `application/sd-jwt`.
     </p>
     <p>
 Some implementations might choose to support less specific media types such as

--- a/index.html
+++ b/index.html
@@ -819,22 +819,22 @@ Return the |uncompressed bitstring|.
     <h2>Media Types</h2>
 
     <p>
-When publishing status list information, issuers SHOULD publish the status list
-using an HTTPS URL and in a way that makes it not possible to correlate usage
-patterns related to the list. When retrieving status list information, verifiers
-SHOULD retrieve the status list over protocols that guard against access
+<a>Issuers</a> SHOULD publish status list information
+using HTTPS URLs and in ways that minimize possible correlation of usage
+patterns related to the list. <a>Verifiers</a>
+SHOULD retrieve status list information using protocols that guard against access
 pattern correlation, such as Oblivious HTTP [[?OHTTP]].
     </p>
 
     <p>
-When dereferencing `statusListCredential`, the content type of the
+When dereferencing `statusListCredential`, the content of the returned
 `statusListCredential` might be any media type registered for the purpose of
 expressing a verifiable credential with one or more proofs.
     </p>
     <p>
 For example, a verifiable credential secured with Data Integrity Proofs might
-have content type `application/vc+ld+json`, whereas a verifiable credential
-secured with SD-JWT might have content-type `application/sd-jwt`.
+have media type `application/vc+ld+json`, while a verifiable credential
+secured with SD-JWT might have media type `application/sd-jwt`.
     </p>
     <p>
 Some implementations might choose to support less specific media types such as


### PR DESCRIPTION
This PR is being raised to address issue #44 by stating that HTTPS should be used to publish status lists and protocols like OHTTP should be used to retrieve status lists.

These normative statements are untestable, so we might want to downgrade this language to advisement in the privacy considerations sections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/107.html" title="Last updated on Dec 30, 2023, 12:05 AM UTC (3293cce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/107/0ffc99b...3293cce.html" title="Last updated on Dec 30, 2023, 12:05 AM UTC (3293cce)">Diff</a>