### PR TITLE
Update BitstringStatusList context to align with latest spec.

### DIFF
--- a/contexts/2021/v1.jsonld
+++ b/contexts/2021/v1.jsonld
@@ -1,0 +1,55 @@
+{
+  "@context": {
+    "@protected": true,
+
+    "StatusList2021Credential": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021Credential",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+
+    "StatusList2021": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusPurpose":
+          "https://w3id.org/vc/status-list#statusPurpose",
+        "encodedList": "https://w3id.org/vc/status-list#encodedList"
+      }
+    },
+
+    "StatusList2021Entry": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021Entry",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusPurpose":
+          "https://w3id.org/vc/status-list#statusPurpose",
+        "statusListIndex":
+          "https://w3id.org/vc/status-list#statusListIndex",
+        "statusListCredential": {
+          "@id":
+            "https://w3id.org/vc/status-list#statusListCredential",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/contexts/v1.jsonld
+++ b/contexts/v1.jsonld
@@ -14,10 +14,8 @@
 
         "statusPurpose":
           "https://www.w3.org/ns/credentials/status-list#statusPurpose",
-        "encodedList": {
-          "@id": "https://www.w3.org/ns/credentials/status-list#encodedList",
-          "@type": "http://www.w3.org/2001/XMLSchema#base64Binary"
-        },
+        "encodedList":
+          "https://www.w3.org/ns/credentials/status-list#encodedList",
         "ttl": "https://www.w3.org/ns/credentials/status-list#ttl",
         "reference": "https://www.w3.org/ns/credentials/status-list#reference",
         "size": "https://www.w3.org/ns/credentials/status-list#size",

--- a/contexts/v1.jsonld
+++ b/contexts/v1.jsonld
@@ -2,23 +2,10 @@
   "@context": {
     "@protected": true,
 
-    "StatusList2021Credential": {
-      "@id":
-        "https://w3id.org/vc/status-list#StatusList2021Credential",
-      "@context": {
-        "@protected": true,
+    "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status-list#BitstringStatusListCredential",
 
-        "id": "@id",
-        "type": "@type",
-
-        "description": "http://schema.org/description",
-        "name": "http://schema.org/name"
-      }
-    },
-
-    "StatusList2021": {
-      "@id":
-        "https://w3id.org/vc/status-list#StatusList2021",
+    "BitstringStatusList": {
+      "@id": "https://www.w3.org/ns/credentials/status-list#BitstringStatusList",
       "@context": {
         "@protected": true,
 
@@ -26,14 +13,32 @@
         "type": "@type",
 
         "statusPurpose":
-          "https://w3id.org/vc/status-list#statusPurpose",
-        "encodedList": "https://w3id.org/vc/status-list#encodedList"
+          "https://www.w3.org/ns/credentials/status-list#statusPurpose",
+        "encodedList": {
+          "@id": "https://www.w3.org/ns/credentials/status-list#encodedList",
+          "@type": "http://www.w3.org/2001/XMLSchema#base64Binary"
+        },
+        "ttl": "https://www.w3.org/ns/credentials/status-list#ttl",
+        "reference": "https://www.w3.org/ns/credentials/status-list#reference",
+        "size": "https://www.w3.org/ns/credentials/status-list#size",
+        "statusMessage": {
+          "@id": "https://www.w3.org/ns/credentials/status-list#statusMessage",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "status": "https://www.w3.org/ns/credentials/status-list#status",
+            "message": "https://www.w3.org/ns/credentials/status-list#message"
+          }
+        }
       }
     },
 
-    "StatusList2021Entry": {
+    "BitstringStatusListEntry": {
       "@id":
-        "https://w3id.org/vc/status-list#StatusList2021Entry",
+        "https://www.w3.org/ns/credentials/status-list#BitstringStatusListEntry",
       "@context": {
         "@protected": true,
 
@@ -41,12 +46,12 @@
         "type": "@type",
 
         "statusPurpose":
-          "https://w3id.org/vc/status-list#statusPurpose",
+          "https://www.w3.org/ns/credentials/status-list#statusPurpose",
         "statusListIndex":
-          "https://w3id.org/vc/status-list#statusListIndex",
+          "https://www.w3.org/ns/credentials/status-list#statusListIndex",
         "statusListCredential": {
           "@id":
-            "https://w3id.org/vc/status-list#statusListCredential",
+            "https://www.w3.org/ns/credentials/status-list#statusListCredential",
           "@type": "@id"
         }
       }

--- a/contexts/v1.jsonld
+++ b/contexts/v1.jsonld
@@ -17,8 +17,10 @@
         "encodedList":
           "https://www.w3.org/ns/credentials/status-list#encodedList",
         "ttl": "https://www.w3.org/ns/credentials/status-list#ttl",
-        "reference": "https://www.w3.org/ns/credentials/status-list#reference",
-        "size": "https://www.w3.org/ns/credentials/status-list#size",
+        "statusReference":
+          "https://www.w3.org/ns/credentials/status-list#statusReference",
+        "statusSize":
+          "https://www.w3.org/ns/credentials/status-list#statusSize",
         "statusMessage": {
           "@id": "https://www.w3.org/ns/credentials/status-list#statusMessage",
           "@context": {

--- a/contexts/v1.jsonld
+++ b/contexts/v1.jsonld
@@ -2,10 +2,10 @@
   "@context": {
     "@protected": true,
 
-    "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status-list#BitstringStatusListCredential",
+    "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
 
     "BitstringStatusList": {
-      "@id": "https://www.w3.org/ns/credentials/status-list#BitstringStatusList",
+      "@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
       "@context": {
         "@protected": true,
 
@@ -13,24 +13,24 @@
         "type": "@type",
 
         "statusPurpose":
-          "https://www.w3.org/ns/credentials/status-list#statusPurpose",
+          "https://www.w3.org/ns/credentials/status#statusPurpose",
         "encodedList":
-          "https://www.w3.org/ns/credentials/status-list#encodedList",
-        "ttl": "https://www.w3.org/ns/credentials/status-list#ttl",
+          "https://www.w3.org/ns/credentials/status#encodedList",
+        "ttl": "https://www.w3.org/ns/credentials/status#ttl",
         "statusReference":
-          "https://www.w3.org/ns/credentials/status-list#statusReference",
+          "https://www.w3.org/ns/credentials/status#statusReference",
         "statusSize":
-          "https://www.w3.org/ns/credentials/status-list#statusSize",
+          "https://www.w3.org/ns/credentials/status#statusSize",
         "statusMessage": {
-          "@id": "https://www.w3.org/ns/credentials/status-list#statusMessage",
+          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
           "@context": {
             "@protected": true,
 
             "id": "@id",
             "type": "@type",
 
-            "status": "https://www.w3.org/ns/credentials/status-list#status",
-            "message": "https://www.w3.org/ns/credentials/status-list#message"
+            "status": "https://www.w3.org/ns/credentials/status#status",
+            "message": "https://www.w3.org/ns/credentials/status#message"
           }
         }
       }
@@ -38,7 +38,7 @@
 
     "BitstringStatusListEntry": {
       "@id":
-        "https://www.w3.org/ns/credentials/status-list#BitstringStatusListEntry",
+        "https://www.w3.org/ns/credentials/status#BitstringStatusListEntry",
       "@context": {
         "@protected": true,
 
@@ -46,12 +46,12 @@
         "type": "@type",
 
         "statusPurpose":
-          "https://www.w3.org/ns/credentials/status-list#statusPurpose",
+          "https://www.w3.org/ns/credentials/status#statusPurpose",
         "statusListIndex":
-          "https://www.w3.org/ns/credentials/status-list#statusListIndex",
+          "https://www.w3.org/ns/credentials/status#statusListIndex",
         "statusListCredential": {
           "@id":
-            "https://www.w3.org/ns/credentials/status-list#statusListCredential",
+            "https://www.w3.org/ns/credentials/status#statusListCredential",
           "@type": "@id"
         }
       }

--- a/index.html
+++ b/index.html
@@ -541,8 +541,8 @@ This status is reversible.
                       <td>
 Used to indicate a status message associated with a <a>verifiable
 credential</a>. The status message descriptions MUST be defined in
-`credentialSubject.statusMessages`. `credentialSubject.size` MUST be specified
-when this `statusPurpose` value is used.
+`credentialSubject.statusMessages`. `credentialSubject.statusSize` MUST be
+specified when this `statusPurpose` value is used.
                       </td>
                     </tr>
                   </tbody>
@@ -577,14 +577,14 @@ HTTP `Cache-Control` header, with the value in this field.
               </td>
             </tr>
             <tr>
-              <td id="size">credentialSubject.size</td>
+              <td>credentialSubject.statusSize</td>
               <td>
-The `size` indicates the size of the status entry in bits. `size` MAY be
-provided. If `size` is not present as a property of the `credentialStatus`, then
-`size` MUST be processed as `1`.  `size` MUST be an integer greater than zero.
-If `size` is provided and is greater than `1`, then the property
-`credentialStatus.statusMessage` MUST be present, and the number of status
-messages must equal the number of possible values.
+The `statusSize` indicates the size of the status entry in bits. `statusSize`
+MAY be provided. If `statusSize` is not present as a property of the
+`credentialStatus`, then `statusSize` MUST be processed as `1`.  `statusSize`
+MUST be an integer greater than zero. If `statusSize` is provided and is greater
+than `1`, then the property `credentialStatus.statusMessage` MUST be present,
+and the number of status messages must equal the number of possible values.
               </td>
             </tr>
             <tr>
@@ -592,9 +592,9 @@ messages must equal the number of possible values.
               <td>
 The `statusMessage` property MUST be an array. If present,
 the length of the array must equal the number of possible status states
-indicated by `size`. `statusMessage` MAY be present if
-`size` is `1`. `statusMessage` MUST be present if
-`size` is greater than `1`.  If not present, the message value
+indicated by `statusSize`. `statusMessages` MAY be present if
+`statusSize` is `1`. `statusMessages` MUST be present if
+`statusSize` is greater than `1`.  If not present, the message value
 associated with the bit value of `0` is "unset" and the bit
 value of `1` is "set".
 If present, elements in the `statusMessage` array MUST contain at
@@ -617,16 +617,16 @@ status codes.
               </td>
             </tr>
             <tr>
-              <td id="reference">credentialSubject.reference</td>
+              <td id="statusReference">credentialSubject.statusReference</td>
               <td>
-The `reference` property provides a point for implementers to include a [[URL]]
-to material related to the status. An implementer MAY include the `reference`
-property, and if they do, the value MUST be a [[URL]] or an array of URLs.
-Implementers using a `statusPurpose` of `status` are strongly encouraged to
-provide a `reference`.
+The `statusReference` property provides a point for implementers to include a
+[[URL]] to material related to the status. An implementer MAY include the
+`statusReference` property, and if they do, the value MUST be a [[URL]] or an
+array of URLs. Implementers using a `statusPurpose` of `status` are strongly
+encouraged to provide a `statusReference`.
                 <p class="note" title="Details around reference">
-`reference` is especially important when interpretation of the status for a
-credential may involve some understanding of the business case involved.
+`statusReference` is especially important when interpretation of the status for
+a credential may involve some understanding of the business case involved.
                 </p>
               </td>
             </tr>
@@ -832,7 +832,7 @@ For each value in `bitstring`, if there is a
 corresponding `statusListIndex` value in
 a credential in `issuedCredentials`, set the value to the
 appropriate status. The position of the value is computed as `statusListIndex`
-times the `size`.
+times the `statusSize`.
         </li>
         <li>
 Generate a |compressed bitstring| by using the GZIP

--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@ HTTP `Cache-Control` header, with the value in this field.
               </td>
             </tr>
             <tr>
-              <td>credentialSubject.statusSize</td>
+              <td id="statusSize">credentialSubject.statusSize</td>
               <td>
 The `statusSize` indicates the size of the status entry in bits. `statusSize`
 MAY be provided. If `statusSize` is not present as a property of the

--- a/vocab/vocabulary.yml
+++ b/vocab/vocabulary.yml
@@ -11,7 +11,7 @@ ontology:
     value: Verifiable Credentials Bitstring Status List v1.0
 
   - property: dc:description
-    value: RDFS [[RDF-SCHEMA]] vocabulary used by the [[[VC-BITSTRING-STATUS-LIST]]] [[VC-BITSTRING-STATUS-LIST]]
+    value: RDFS [[RDF-SCHEMA]] vocabulary used by the [[[VC-BITSTRING-STATUS-LIST]]] [[VC-BITSTRING-STATUS-LIST]]
 
   - property: rdfs:seeAlso
     value: https://www.w3.org/TR/vc-bitstring-status-list/
@@ -64,7 +64,7 @@ property:
 
   - id: size
     label: Bitstring entry size in bits
-    defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#size
+    defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusSize
     domain: cs:BitstringStatusList
     range: xsd:string
 
@@ -86,6 +86,6 @@ property:
 
   - id: reference
     label: Reference documentation for status messages
-    defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#reference
+    defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusReference
     domain: cs:BitstringStatusList
     range: xsd:string


### PR DESCRIPTION
This PR is an attempt at addressing issue #70, which updates the context to align with the latest specification. 

It preserves the old 2021 status list since that's where the w3id.org redirect goes currently, and we believe some organizations have deployed 2021 status list into potentially production environments. We need to preserve that file for now in order to not break implementations that aren't (mistakenly) caching their JSON-LD Contexts until we can move it back to the CCG or host it elsewhere (or decide to continue hosting it here).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/109.html" title="Last updated on Jan 13, 2024, 4:38 PM UTC (33d25b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/109/887193d...33d25b7.html" title="Last updated on Jan 13, 2024, 4:38 PM UTC (33d25b7)">Diff</a>