### PR TITLE
Clarify base64 encoding as base64url encoding.

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@ with this `statusPurpose`.
                 <td>credentialSubject.encodedList</td>
               <td>
 The `encodedList` property of the credential <a>subject</a> MUST be
-the GZIP-compressed [[RFC1952]], base64url-encoded [[RFC4648]] bitstring values
+the GZIP-compressed [[RFC1952]], base64url-encoded (with no padding) [[RFC4648]] bitstring values
 for the associated range of <a>verifiable credential</a> status values. The
 uncompressed bitstring MUST be at least 16KB in size. The bitstring MUST be
 encoded such that the first index, with a value of zero
@@ -778,7 +778,7 @@ times the `size`.
         <li>
 Generate a |compressed bitstring| by using the GZIP
 compression algorithm [[RFC1952]] on the |bitstring|
-and then base64url-encoding [[RFC4648]] the result.
+and then base64url-encoding (with no padding) [[RFC4648]] the result.
         </li>
         <li>
 Return the |compressed bitstring|.
@@ -803,7 +803,7 @@ bitstring.
         </li>
         <li>
 Generate an |uncompressed bitstring| by using the
-base64url-decoding [[RFC4648]] algorithm on the
+base64url-decoding (with no padding) [[RFC4648]] algorithm on the
 |compressed bitstring| and then expanding the output using
 the GZIP decompression algorithm [[RFC1952]].
         </li>

--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@ with this `statusPurpose`.
                 <td>credentialSubject.encodedList</td>
               <td>
 The `encodedList` property of the credential <a>subject</a> MUST be
-the GZIP-compressed [[RFC1952]], base-64 encoded [[RFC4648]] bitstring values
+the GZIP-compressed [[RFC1952]], base64url-encoded [[RFC4648]] bitstring values
 for the associated range of <a>verifiable credential</a> status values. The
 uncompressed bitstring MUST be at least 16KB in size. The bitstring MUST be
 encoded such that the first index, with a value of zero
@@ -778,7 +778,7 @@ times the `size`.
         <li>
 Generate a |compressed bitstring| by using the GZIP
 compression algorithm [[RFC1952]] on the |bitstring|
-and then base64-encoding [[RFC4648]] the result.
+and then base64url-encoding [[RFC4648]] the result.
         </li>
         <li>
 Return the |compressed bitstring|.
@@ -803,7 +803,7 @@ bitstring.
         </li>
         <li>
 Generate an |uncompressed bitstring| by using the
-base64-decoding [[RFC4648]] algorithm on the
+base64url-decoding [[RFC4648]] algorithm on the
 |compressed bitstring| and then expanding the output using
 the GZIP decompression algorithm [[RFC1952]].
         </li>


### PR DESCRIPTION
This PR is an attempt to address issue #58 by clarifying that the base-encoding mechanism for `encodedList` is base64url.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/110.html" title="Last updated on Dec 30, 2023, 12:09 AM UTC (a12e3e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/110/882b52f...a12e3e9.html" title="Last updated on Dec 30, 2023, 12:09 AM UTC (a12e3e9)">Diff</a>