### PR TITLE
Add mechanism to retrieve historical status list information.

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,10 +814,10 @@ issuer, such as hourly, daily, or weekly. If such a feature is supported, and if
 query parameters are supported by the URL scheme, then the name of the query
 parameter MUST be `timestamp` and the value MUST be a valid URL-encoded
 [[XMLSCHEMA11-2]] dateTimeStamp string value. The result of dereferencing such a
-timestamped URL MUST be a status list credential containing either the status
-list as it existed at the given point in time, or a <a
-href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>. If the result is an
-error, implementations MAY attempt the retrieval again with a different
+timestamp-parameterized URL MUST be either a status list credential containing
+the status list as it existed at the given point in time, or a
+<a href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>. If the result is
+an error, implementations MAY attempt the retrieval again with a different
 timestamp value, or without a timestamp value, as long as the <a>verifier</a>'s
 validation rules permit such an action.
       </p>

--- a/index.html
+++ b/index.html
@@ -812,8 +812,8 @@ feature is supported, and if query parameters are supported by the URL scheme,
 then the name of the query parameter MUST be `timestamp` and the value MUST be
 a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value. The result of
 dereferencing such a timestamped URL MUST be a status list credential containing
-either the status list as it existed at the given point in time, or an error.
-point in time.
+either the status list as it existed at the given point in time, or a 
+<a href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>.
       </p>
 
 

--- a/index.html
+++ b/index.html
@@ -805,6 +805,17 @@ Return |result|.
         </li>
       </ol>
 
+      <p>
+When dereferencing a `statusListCredential` URL, implementations MAY provide a
+mechanism to query the status list at a particular point in time. If such a
+feature is supported, and if query parameters are supported by the URL scheme,
+then the name of the query parameter MUST be `timestamp` and the value MUST be
+a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value. The resulting
+status list credential SHOULD be the status list as it existed at the given
+date and time.
+      </p>
+
+
       <p class="note" title="Issuer validation is use case dependent">
 It is expected that a <a>verifier</a> will ensure that it trusts the issuer
 of a <a>verifiable credential</a>, as well as the issuer of the associated

--- a/index.html
+++ b/index.html
@@ -806,13 +806,13 @@ Return |result|.
       </ol>
 
       <p>
-When dereferencing a `statusListCredential` URL, implementations MAY provide a
-mechanism to query the status list at a particular point in time. If such a
+When a `statusListCredential` URL is dereferenced, server implementations MAY provide a
+mechanism to dereference the status list as of a particular point in time. If such a
 feature is supported, and if query parameters are supported by the URL scheme,
 then the name of the query parameter MUST be `timestamp` and the value MUST be
 a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value. The resulting
 status list credential SHOULD be the status list as it existed at the given
-date and time.
+point in time.
       </p>
 
 

--- a/index.html
+++ b/index.html
@@ -810,8 +810,9 @@ When a `statusListCredential` URL is dereferenced, server implementations MAY pr
 mechanism to dereference the status list as of a particular point in time. If such a
 feature is supported, and if query parameters are supported by the URL scheme,
 then the name of the query parameter MUST be `timestamp` and the value MUST be
-a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value. The resulting
-status list credential SHOULD be the status list as it existed at the given
+a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value. The result of
+dereferencing such a timestamped URL MUST be a status list credential containing
+either the status list as it existed at the given point in time, or an error.
 point in time.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -808,15 +808,18 @@ Return |result|.
       <p>
 When a `statusListCredential` URL is dereferenced, server implementations MAY
 provide a mechanism to dereference the status list as of a particular point in
-time. If such a feature is supported, and if query parameters are supported by
-the URL scheme, then the name of the query parameter MUST be `timestamp` and the
-value MUST be a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value.
-The result of dereferencing such a timestamped URL MUST be a status list
-credential containing either the status list as it existed at the given point in
-time, or a <a href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>.
-If the result is an error, implementations MAY attempt the retrieval again
-with a different timestamp value, or without a timestamp value, as long as
-the <a>verifier</a>'s validation rules permit such an action.
+time. When an <a>issuer</a> provides such a mechanism, it enables a
+<a>verifier</a> to determine changes in status to a precision chosen by the
+issuer, such as hourly, daily, or weekly. If such a feature is supported, and if
+query parameters are supported by the URL scheme, then the name of the query
+parameter MUST be `timestamp` and the value MUST be a valid URL-encoded
+[[XMLSCHEMA11-2]] dateTimeStamp string value. The result of dereferencing such a
+timestamped URL MUST be a status list credential containing either the status
+list as it existed at the given point in time, or a <a
+href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>. If the result is an
+error, implementations MAY attempt the retrieval again with a different
+timestamp value, or without a timestamp value, as long as the <a>verifier</a>'s
+validation rules permit such an action.
       </p>
 
       <p class="note" title="Issuer validation is use case dependent">

--- a/index.html
+++ b/index.html
@@ -806,16 +806,18 @@ Return |result|.
       </ol>
 
       <p>
-When a `statusListCredential` URL is dereferenced, server implementations MAY provide a
-mechanism to dereference the status list as of a particular point in time. If such a
-feature is supported, and if query parameters are supported by the URL scheme,
-then the name of the query parameter MUST be `timestamp` and the value MUST be
-a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value. The result of
-dereferencing such a timestamped URL MUST be a status list credential containing
-either the status list as it existed at the given point in time, or a 
-<a href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>.
+When a `statusListCredential` URL is dereferenced, server implementations MAY
+provide a mechanism to dereference the status list as of a particular point in
+time. If such a feature is supported, and if query parameters are supported by
+the URL scheme, then the name of the query parameter MUST be `timestamp` and the
+value MUST be a valid URL-encoded [[XMLSCHEMA11-2]] dateTimeStamp string value.
+The result of dereferencing such a timestamped URL MUST be a status list
+credential containing either the status list as it existed at the given point in
+time, or a <a href="#STATUS_RETRIEVAL_ERROR">STATUS_RETRIEVAL_ERROR</a>.
+If the result is an error, implementations MAY attempt the retrieval again
+with a different timestamp value, or without a timestamp value, as long as
+the <a>verifier</a>'s validation rules permit such an action.
       </p>
-
 
       <p class="note" title="Issuer validation is use case dependent">
 It is expected that a <a>verifier</a> will ensure that it trusts the issuer


### PR DESCRIPTION
This PR is an attempt to address issue #94 by adding an optional normative mechanism to retrieve historical status list information.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/112.html" title="Last updated on Jan 13, 2024, 5:59 PM UTC (dfa5e31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/112/b6883e5...dfa5e31.html" title="Last updated on Jan 13, 2024, 5:59 PM UTC (dfa5e31)">Diff</a>