### PR TITLE
Add privacy consideration section about Multistatus Correlation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,6 +914,35 @@ information from presented credentials with a malicious <a>issuer</a>.
       </p>
     </section>
 
+    <section class="informative">
+      <h3>Multistatus Correlation</h3>
+      <p>
+This specification provides a means by which multiple status messages can be
+provided for a particular entry in a status list. While this mechanism can
+provide more detailed information for a particular entry in the status list,
+that information can provide further correlation data.
+      </p>
+      <p>
+For example, if each status message is associated with a step in a particular
+process, or more detailed information for why a credential was revoked or
+suspended, then an attacker that observes the changes in the list might be
+able to correlate information about the population of entities in the list
+that could lead to privacy violations. Understanding how a population
+progresses through a business process, or what percentage of the population
+is likely to be associated with a certain status, provides additional
+information to an attacker. Given such information, a phishing operation could
+predict what the next step of a business process is and then preemptively
+contact an entity based on that information, whose current status is known, in
+an attempt to phish more lucrative information from them using data gleaned
+from the status list over time.
+      </p>
+      <p>
+For these reasons, issuers are urged to evaluate the potential ramifications of
+publishing detailed status information about a particular entity, or a
+population, in a public manner.
+      </p>
+    </section>
+
   </section>
 
   <section class="informative">

--- a/index.html
+++ b/index.html
@@ -924,7 +924,7 @@ that information can provide further correlation data.
       </p>
       <p>
 For example, if each status message is associated with a step in a particular
-process, or more detailed information for why a credential was revoked or
+process, or more detailed information as to why a credential was revoked or
 suspended, then an attacker that observes the changes in the list might be
 able to correlate information about the population of entities in the list
 that could lead to privacy violations. Understanding how a population
@@ -932,8 +932,8 @@ progresses through a business process, or what percentage of the population
 is likely to be associated with a certain status, provides additional
 information to an attacker. Given such information, a phishing operation could
 predict what the next step of a business process is and then preemptively
-contact an entity based on that information, whose current status is known, in
-an attempt to phish more lucrative information from them using data gleaned
+contact an entity whose current status is known, and then based on that information
+attempt to phish more lucrative information from it using data gleaned
 from the status list over time.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -932,9 +932,9 @@ progresses through a business process, or what percentage of the population
 is likely to be associated with a certain status, provides additional
 information to an attacker. Given such information, a phishing operation could
 predict what the next step of a business process is and then preemptively
-contact an entity whose current status is known, and then based on that information
-attempt to phish more lucrative information from it using data gleaned
-from the status list over time.
+contact an entity whose current status is known. Then, based on that 
+information, they could attempt to phish more lucrative information from 
+the target using data gleaned from the status list over time.
       </p>
       <p>
 For these reasons, issuers are urged to evaluate the potential ramifications of


### PR DESCRIPTION
This PR is an attempt to address issue #86 by adding a privacy considerations section about Multistatus Correlation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/117.html" title="Last updated on Jan 2, 2024, 8:40 PM UTC (c5bd70a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/117/a0a5eb3...c5bd70a.html" title="Last updated on Jan 2, 2024, 8:40 PM UTC (c5bd70a)">Diff</a>