### PR TITLE
Add "at risk" marker noting bitstring format might change in CR.

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,6 +705,19 @@ not complying with associated "MUST" statements, a
 MUST be raised.
     </p>
 
+    <p class="issue atrisk"
+       title="Attempting alignment with IETF Token Status List specification">
+The Working Group is seeking feedback related to implementer desire to align
+with the IETF OAuth Working Group
+<a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/">
+Token Status List</a> specification. If there is interest,
+and to the extent possible, this specification might align
+more closely with the Token Status List bitstring format, as it could be
+beneficial to have the same code base able to process bitstring values from
+both lists. If there is implementer support for these changes, these changes
+might be made during the Candidate Recommendation phase.
+    </p>
+
     <section class="normative">
       <h3>Generate Algorithm</h3>
 

--- a/index.html
+++ b/index.html
@@ -710,11 +710,13 @@ MUST be raised.
 The Working Group is seeking feedback related to implementer desire to align
 with the IETF OAuth Working Group
 <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/">
-Token Status List</a> specification. If there is interest,
+Token Status List</a> specification (formerly titled <i>OAuth Status List</i>, and
+<a href="https://datatracker.ietf.org/doc/draft-looker-oauth-jwt-cwt-status-list/01/">
+<i>JWT and CWT Status List</i></a>). If there is interest,
 and to the extent possible, this specification might align
 more closely with the Token Status List bitstring format, as it could be
-beneficial to have the same code base able to process bitstring values from
-both lists. If there is implementer support for these changes, these changes
+beneficial to have one code base able to process bitstring values from
+both lists. If there is implementer support for such changes, they
 might be made during the Candidate Recommendation phase.
     </p>
 


### PR DESCRIPTION
This PR is an attempt to address issue #93 by adding an at risk issue marker to note that the bitstring format might change during the Candidate Recommendation phase if there is implementer interest to align more closely with the IETF Token Status List specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/119.html" title="Last updated on Jan 13, 2024, 8:59 PM UTC (078db10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/119/9a44436...078db10.html" title="Last updated on Jan 13, 2024, 8:59 PM UTC (078db10)">Diff</a>