### PR TITLE
Add examples for multiple status lists and multiple entries in a single status list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1312,6 +1312,11 @@ data-vc-vm='https://example.edu/issuers/565049/keys/1'>
       <section>
         <h2>Multiple Status Lists in One Verifiable Credential</h2>
 
+        <p>
+This specification enables an <a>issuer</a> to associate multiple status lists
+with a single <a>verifiable credential</a>.
+        </p>
+
         <pre class="example nohighlight vc"
              title="Associating multiple status lists with a single Verifiable Credential"
              data-vc-vm='https://example.edu/issuers/565049/keys/1'>
@@ -1349,6 +1354,33 @@ data-vc-vm='https://example.edu/issuers/565049/keys/1'>
 
       <section>
         <h2>Multiple Status Entries in a Single List</h2>
+
+        <p>
+It is possible for a single status list to contain multiple types of status
+purposes. Doing so can make the retrieval of a list slightly more efficient
+than fetching multiple status lists.
+        </p>
+
+        <p class="issue atrisk" title="Efficiency argument is weak">
+The "space efficiency" argument for this feature is weak. Fetching one list
+with two types of status entries must, presumably, be twice as long to ensure
+proper privacy protections. One privacy benefit of doing so is that bit flips
+cannot be known to be associated with a particular status unless one is also in
+control of the VC that the status is about. Therefore, mixing "revocation" and
+"suspension" in a single list that is twice as large has positive privacy
+implications.<br><br>
+The "retrieval efficiency" argument is also weak. Performing two HTTP retrievals
+instead of one is probably not significant. Performing upwards of five to six,
+on a list that is five to six times larger, might result in fairly meager
+savings over modern versions of HTTP that bundle requests over a single channel
+(such as HTTP/2 or HTTP/3). The requests themselves would be a handful of bytes
+that are saved with no significant improvement in retrieval speed.<br><br>
+The Working Group is looking for feedback from implementers and is considering
+striking this feature during the Candidate Recommendation period since it would
+simplify the specification for implementations to not have to support sets of
+`proofPurpose` values in the status list credentials (again, a meager savings in
+complexity).
+        </p>
 
         <pre class="example nohighlight vc"
              title="Associating multiple status entries in a single status list"

--- a/index.html
+++ b/index.html
@@ -512,9 +512,9 @@ status list, MUST be `BitstringStatusList`.
             <tr>
               <td id="statusPurpose">credentialSubject.statusPurpose</td>
               <td>
-The purpose of the status entry MUST be one or more strings. While the value of
-each string is arbitrary, the following values MUST be used for their intended
-purpose:
+The value of the purpose property of the status entry, `statusPurpose`, MUST be
+one or more strings. While the value of each string is arbitrary, the following
+values MUST be used for their intended purpose:
                 <table class="simple">
                   <thead>
                     <tr>
@@ -1379,7 +1379,7 @@ that are saved with no significant improvement in retrieval speed.<br><br>
 The Working Group is looking for feedback from implementers and is considering
 striking this feature during the Candidate Recommendation period since it would
 simplify the specification for implementations to not have to support sets of
-`proofPurpose` values in the status list credentials (again, a meager savings in
+`statusPurpose` values in the status list credentials (again, a meager savings in
 complexity).
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1256,6 +1256,7 @@ Write i18n considerations.
     <h2>Appendix</h2>
     <section>
       <h2>Examples</h2>
+
       <section>
         <h2>Revocable Verifiable Credential</h2>
 <pre class="example nohighlight vc" title="A Revocable Verifiable Credential"
@@ -1284,6 +1285,7 @@ data-vc-vm='https://example.edu/issuers/565049/keys/1'>
 </pre>
 
       </section>
+
       <section>
         <h2>Status List Verifiable Credential</h2>
 <pre class="example nohighlight vc" title="A Status List Verifiable Credential"
@@ -1306,6 +1308,47 @@ data-vc-vm='https://example.edu/issuers/565049/keys/1'>
 }
 </pre>
       </section>
+
+      <section>
+        <h2>Multiple Status Lists in One Verifiable Credential</h2>
+
+        <pre class="example nohighlight vc"
+             title="Associating multiple status lists with a single Verifiable Credential"
+             data-vc-vm='https://example.edu/issuers/565049/keys/1'>
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://example.com/credentials/23894672394",
+  "type": ["VerifiableCredential"],
+  "issuer": "did:example:12345",
+  "issuanceDate": "2021-04-05T14:27:42Z",
+  <span class="comment">// note the use of an array to represent the set of
+  // status entries</span>
+  "credentialStatus": <span class="highlight">[{
+    "id": "https://example.com/credentials/status/3#94567",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "94567",
+    "statusListCredential": "https://example.com/credentials/status/3"
+  }, {
+    "id": "https://example.com/credentials/status/4#12345",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "suspension",
+    "statusListIndex": "12345",
+    "statusListCredential": "https://example.com/credentials/status/4"
+  }]</span>,
+  "credentialSubject": {
+    "id": "did:example:6789",
+    "type": "Person"
+  }
+}
+        </pre>
+      </section>
+
+
+
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -1363,24 +1363,24 @@ than fetching multiple status lists.
         </p>
 
         <p class="issue atrisk" title="Efficiency argument is weak">
-The "space efficiency" argument for this feature is weak. Fetching one list
-with two types of status entries must, presumably, be twice as long to ensure
-proper privacy protections. One privacy benefit of doing so is that bit flips
-cannot be known to be associated with a particular status unless one is also in
-control of the VC that the status is about. Therefore, mixing "revocation" and
-"suspension" in a single list that is twice as large has positive privacy
-implications.<br><br>
+The "space efficiency" argument for this feature is weak. One list with two types
+of status entries must, presumably, be twice as long as a list with one type of
+status entries, to ensure proper privacy protections. One privacy benefit of
+doing so is that bit flips cannot be known to be associated with a particular
+status unless one is also in control of the VC that the status is about.
+Therefore, mixing "revocation" and "suspension" in a single list that is twice
+as large has positive privacy implications.<br><br>
 The "retrieval efficiency" argument is also weak. Performing two HTTP retrievals
-instead of one is probably not significant. Performing upwards of five to six,
-on a list that is five to six times larger, might result in fairly meager
+instead of one is probably not significant. Performing upwards of five or six,
+on a list that is five or six times larger, might result in fairly meager
 savings over modern versions of HTTP that bundle requests over a single channel
-(such as HTTP/2 or HTTP/3). The requests themselves would be a handful of bytes
-that are saved with no significant improvement in retrieval speed.<br><br>
+(such as HTTP/2 or HTTP/3). The requests themselves would save a handful of
+bytes with no significant improvement in retrieval speed.<br><br>
 The Working Group is looking for feedback from implementers and is considering
-striking this feature during the Candidate Recommendation period since it would
+striking this feature during the Candidate Recommendation period, since it would
 simplify the specification for implementations to not have to support sets of
-`statusPurpose` values in the status list credentials (again, a meager savings in
-space efficiency vs. retrieval efficiency).
+`statusPurpose` values in the status list credentials (again, a meager savings
+in space efficiency at a small cost to retrieval efficiency).
         </p>
 
         <pre class="example nohighlight vc"

--- a/index.html
+++ b/index.html
@@ -1261,7 +1261,7 @@ Write i18n considerations.
       <section>
         <h2>Revocable Verifiable Credential</h2>
 <pre class="example nohighlight vc" title="A Revocable Verifiable Credential"
-data-vc-vm='https://example.edu/issuers/565049/keys/1'>
+data-vc-vm="https://example.edu/issuers/565049/keys/1">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -1290,7 +1290,7 @@ data-vc-vm='https://example.edu/issuers/565049/keys/1'>
       <section>
         <h2>Status List Verifiable Credential</h2>
 <pre class="example nohighlight vc" title="A Status List Verifiable Credential"
-data-vc-vm='https://example.edu/issuers/565049/keys/1'>
+data-vc-vm="https://example.edu/issuers/565049/keys/1">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",

--- a/index.html
+++ b/index.html
@@ -512,8 +512,8 @@ status list, MUST be `BitstringStatusList`.
             <tr>
               <td id="statusPurpose">credentialSubject.statusPurpose</td>
               <td>
-The purpose of the status entry MUST be a string. While the value of the
-string is arbitrary, the following values MUST be used for their intended
+The purpose of the status entry MUST be one or more strings. While the value of
+each string is arbitrary, the following values MUST be used for their intended
 purpose:
                 <table class="simple">
                   <thead>
@@ -790,8 +790,9 @@ proof verifications fail, raise a
 <a href="#STATUS_VERIFICATION_ERROR">STATUS_VERIFICATION_ERROR</a>.
         </li>
         <li>
-Verify that the |status purpose| is equal to the
-`statusPurpose` value in the |statusListCredential|. If the values are not
+Verify that the |status purpose| is equal to a `statusPurpose` value in the
+|statusListCredential|. Note: The |statusListCredential| might contain multiple
+status purposes in a single list. If the values are not
 equal, raise a
 <a href="#STATUS_VERIFICATION_ERROR">STATUS_VERIFICATION_ERROR</a>.
         </li>

--- a/index.html
+++ b/index.html
@@ -1347,7 +1347,43 @@ data-vc-vm='https://example.edu/issuers/565049/keys/1'>
         </pre>
       </section>
 
+      <section>
+        <h2>Multiple Status Entries in a Single List</h2>
 
+        <pre class="example nohighlight vc"
+             title="Associating multiple status entries in a single status list"
+             data-vc-vm='https://example.edu/issuers/565049/keys/1'>
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://example.com/credentials/23894672394",
+  "type": ["VerifiableCredential"],
+  "issuer": "did:example:12345",
+  "issuanceDate": "2021-04-05T14:27:42Z",
+  <span class="comment">// note the use of a single list to store multiple
+  // status entries</span>
+  "credentialStatus": [{
+    "id": "<span class="highlight">https://example.com/credentials/status/5#94567</span>",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "94567",
+    "statusListCredential": "<span class="highlight">https://example.com/credentials/status/5</span>"
+  }, {
+    "id": "<span class="highlight">https://example.com/credentials/status/5#12345</span>",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "suspension",
+    "statusListIndex": "12345",
+    "statusListCredential": "<span class="highlight">https://example.com/credentials/status/5</span>"
+  }],
+  "credentialSubject": {
+    "id": "did:example:6789",
+    "type": "Person"
+  }
+}
+        </pre>
+      </section>
 
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -1380,7 +1380,7 @@ The Working Group is looking for feedback from implementers and is considering
 striking this feature during the Candidate Recommendation period since it would
 simplify the specification for implementations to not have to support sets of
 `statusPurpose` values in the status list credentials (again, a meager savings in
-complexity).
+space efficiency vs. retrieval efficiency).
         </p>
 
         <pre class="example nohighlight vc"


### PR DESCRIPTION
This PR is an attempt at addressing [some comments](https://github.com/w3c/vc-bitstring-status-list/issues/73#issuecomment-1872490184) in issue #73 by adding examples for multiple status lists and multiple entries in a single status list.

Note: This PR contains a normative change to support the last example with multiple status types stored in a single list. It also has an at-risk marker for the feature as the more I wrote about the feature, the less of a benefit there seemed to be. The strongest benefit seems to be a privacy argument (if you mix in multiple statuses in a single list, and the bits for each status don't sit beside one another, it's hard to tell which type of status bit is being flipped to an outside observer -- which improves the privacy characteristics of the list).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/122.html" title="Last updated on Jan 13, 2024, 9:19 PM UTC (4a51b3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/122/c53823f...4a51b3b.html" title="Last updated on Jan 13, 2024, 9:19 PM UTC (4a51b3b)">Diff</a>