### PR TITLE
Add at risk issue marker regarding multibit status entries.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ in the relevant W3C Working Group or make a non-member patent licensing
 commitment.
 
 If you are not the sole contributor to a contribution (pull request), please
-identify all  contributors in the pull request comment.
+identify all contributors in the pull request comment.
 
-To add a contributor (other than yourself, that's automatic), mark them one per
+To add a contributor (other than yourself; that's automatic), mark them one per
 line as follows:
 
 ```

--- a/index.html
+++ b/index.html
@@ -462,13 +462,13 @@ the <a>verifiable credential</a> that encapsulates the status list:
 
         <p class="issue atrisk"
            title="Bitstring entry sizes greater than 1 are at risk.">
-The Working Group is currently seeking implementer feedback with respect to the
-usefulness of bitstring entries that have sizes greater than one. The
-approach adds complexity to the solution and its not clear if there is
-enough of an implementation community to support the feature. The WG is
-considering three options 1) keep the feature, 2) allow the feature to be
-optionally supported, and 3) remove the feature. At present, the specification
-implements the second option.
+The Working Group is currently seeking implementer feedback regarding the
+utility of bitstring entries that have sizes greater than one. Supporting
+such entries adds complexity to the solution, and it's not clear whether there
+is enough of an implementation community to support the feature. The WG is
+considering three options: (1) require conforming implementations to support
+the feature; (2) allow implementations to optionally support the feature; or
+(3) remove the feature. At present, the specification implements option (2).
         </p>
 
         <table class="simple">

--- a/index.html
+++ b/index.html
@@ -303,7 +303,8 @@ data model that follows the relevant normative requirements in Section
 A <dfn>conforming processor</dfn> is any algorithm realized
 as software and/or hardware that generates and/or consumes a
 <a>conforming document</a> according to the relevant normative statements in
-Section <a href="#algorithms"></a>. Conforming processors MUST produce errors
+Section <a href="#algorithms"></a>. Conforming processors MAY choose to only
+support bitstring entry sizes of 1. Conforming processors MUST produce errors
 when non-conforming documents are consumed.
         </p>
 
@@ -457,6 +458,17 @@ When a status list <a>verifiable credential</a> is published, it MUST be a
 conforming document, as defined in [[VC-DATA-MODEL-2.0]], that expresses the
 data model in this section. The following section describes the format of
 the <a>verifiable credential</a> that encapsulates the status list:
+        </p>
+
+        <p class="issue atrisk"
+           title="Bitstring entry sizes greater than 1 are at risk.">
+The Working Group is currently seeking implementer feedback with respect to the
+usefulness of bitstring entries that have sizes greater than one. The
+approach adds complexity to the solution and its not clear if there is
+enough of an implementation community to support the feature. The WG is
+considering three options 1) keep the feature, 2) allow the feature to be
+optionally supported, and 3) remove the feature. At present, the specification
+implements the second option.
         </p>
 
         <table class="simple">


### PR DESCRIPTION
This PR is an attempt at addressing [some comments](https://github.com/w3c/vc-bitstring-status-list/issues/73#issuecomment-1872490184) in issue #73 by marking the multibit status entry feature as at risk. The PR makes it such that implementers don't have to implement the feature to have a conforming processor, but allows implementations that need the feature to implement it in an interoperable fashion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/123.html" title="Last updated on Jan 2, 2024, 8:47 PM UTC (2d24d4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/123/9988e57...2d24d4a.html" title="Last updated on Jan 2, 2024, 8:47 PM UTC (2d24d4a)">Diff</a>