### PR TITLE
Add at risk issue marker for TTL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,8 +444,7 @@ includes the `BitstringStatusListCredential` value.
   "credentialSubject": {
     "id": "did:example:6789",
     "type": "Person"
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
       </section>
@@ -469,6 +468,25 @@ is enough of an implementation community to support the feature. The WG is
 considering three options: (1) require conforming implementations to support
 the feature; (2) allow implementations to optionally support the feature; or
 (3) remove the feature. At present, the specification implements option (2).
+        </p>
+
+
+        <p class="issue atrisk" title="TTL conflicts with `validUntil`">
+The Working Group is considering the removal of the `ttl` feature because it
+conflicts with the semantics of the `validFrom` feature in a
+<a>verifiable credential</a>. When a <a>verifier</a> performs validation, and
+evaluates a `BitstringStatusListCredential` that contains a `ttl` property and a
+`validUntil` property, it is not clear which property can be ignored from a
+validation standpoint if both fields do not "expire" the credential at the
+same point in time. In other words, if a `ttl` value specifies an expiration
+datetime that ends at midnight, but the `validUntil` property specifies an
+expiration datetime that ends at the end of the week, then what is a
+<a>verifier</a> expected to do? Fundamentally, `ttl` and `validUntil` have
+conflicting semantics. The alternative is to remove `ttl` and specify that
+caching behavior can be expressed using protocol mechanisms, such as the
+`expires` header in HTTP and that any caching performed MUST align with the
+`validUntil` value for the <a>verifiable credential</a>. The Working Group is
+seeking feedback from the implementer community regarding this feature.
         </p>
 
         <table class="simple">
@@ -660,8 +678,7 @@ a credential may involve some understanding of the business case involved.
     "type": "<span class="highlight">BitstringStatusList</span>",
     "statusPurpose": "<span class="highlight">revocation</span>",
     "encodedList": "<span class="highlight">H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA</span>"
-  },
-  "proof": { ... }
+  }
 }
         </pre>
         <p class="issue" data-number="73" title="Design of multiple status messages is not finalized.">
@@ -671,6 +688,7 @@ with multiple states (exposed via a series of status messages). We are seeking
 implementer feedback on what a unified design should look like from an ease of
 implementation, privacy, and security standpoint.
         </p>
+
         <pre class="example nohighlight" title="Example BitstringStatusListCredential">
 {
   "@context": [

--- a/index.html
+++ b/index.html
@@ -472,19 +472,20 @@ the feature; (2) allow implementations to optionally support the feature; or
 
 
         <p class="issue atrisk" title="TTL conflicts with `validUntil`">
-The Working Group is considering the removal of the `ttl` feature because it
-conflicts with the semantics of the `validUntil` feature in a
-<a>verifiable credential</a>. When a <a>verifier</a> performs validation, and
-evaluates a `BitstringStatusListCredential` that contains a `ttl` property and a
-`validUntil` property, it is not clear which property can be ignored from a
-validation standpoint if both fields do not "expire" the credential at the
-same point in time. In other words, if a `ttl` value specifies an expiration
-datetime that ends at midnight, but the `validUntil` property specifies an
-expiration datetime that ends at the end of the week, then what is a
-<a>verifier</a> expected to do? Fundamentally, `ttl` and `validUntil` have
-conflicting semantics. The alternative is to remove `ttl` and specify that
-caching behavior can be expressed using protocol mechanisms, such as the
-`expires` header in HTTP and that any caching performed MUST align with the
+The Working Group is considering the removal of the `ttl` ("time to live")
+feature because its semantics conflict with the semantics of the `validUntil`
+feature of <a>verifiable credentials</a>. When a <a>verifier</a> performs
+validation and evaluates a `BitstringStatusListCredential` that contains both
+a `ttl` property and a `validUntil` property, each with a different value
+(i.e., each indicating a different point in time when the credential is to
+"expire"), it is not clear which (if either) property a validator can be
+expected to ignore. In other words, if a `ttl` value specifies an expiration
+datetime of midnight today, but the `validUntil` property specifies an
+expiration datetime of midnight tomorrow, then what is a <a>verifier</a>
+expected to do? Fundamentally, `ttl` and `validUntil` have conflicting
+semantics. One way to resolve this conflict is to remove `ttl` and specify
+that caching behavior can be expressed using protocol mechanisms (such as the
+`expires` header in HTTP), and that any caching performed MUST align with the
 `validUntil` value for the <a>verifiable credential</a>. The Working Group is
 seeking feedback from the implementer community regarding this feature.
         </p>

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@ the feature; (2) allow implementations to optionally support the feature; or
 
         <p class="issue atrisk" title="TTL conflicts with `validUntil`">
 The Working Group is considering the removal of the `ttl` feature because it
-conflicts with the semantics of the `validFrom` feature in a
+conflicts with the semantics of the `validUntil` feature in a
 <a>verifiable credential</a>. When a <a>verifier</a> performs validation, and
 evaluates a `BitstringStatusListCredential` that contains a `ttl` property and a
 `validUntil` property, it is not clear which property can be ignored from a


### PR DESCRIPTION
This PR is an attempt to address issue #120 by adding an at risk issue marker regarding the conflict between the `ttl` value and the `validUntil` value. The PR also removes the ellipsis around `proof` since we did that in the main spec as well. As soon as we update `respec-vc`, we'll add examples encoded in DI and SD-JWT.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/128.html" title="Last updated on Jan 21, 2024, 11:07 PM UTC (05bccaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/128/3c87c08...05bccaf.html" title="Last updated on Jan 21, 2024, 11:07 PM UTC (05bccaf)">Diff</a>