### PR TITLE
Explicitly allow `issuer` to be different between VC and BSLC.

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,6 +699,17 @@ implementation, privacy, and security standpoint.
         </pre>
       </section>
 
+      <p>
+<a>Issuers</a> and <a>verifiers</a> are advised that the `issuer` of a
+<a>verifiable credential</a> and the issuer of an associated
+`BitstringStatusListCredential` might not be the same. There can be technical,
+legal, institutional, and political reasons to separate the authority over the
+original credential from the authority to revoke such a credential. Therefore,
+the `issuer` value of a <a>verifiable credential</a> containing a
+`BitstringStatusListEntry` MAY be different from the `issuer` value of a
+`BitstringStatusListCredential`.
+      </p>
+
     </section>
 
   <section class="normative">

--- a/index.html
+++ b/index.html
@@ -701,13 +701,13 @@ implementation, privacy, and security standpoint.
 
       <p>
 <a>Issuers</a> and <a>verifiers</a> are advised that the `issuer` of a
-<a>verifiable credential</a> and the issuer of an associated
-`BitstringStatusListCredential` might not be the same. There can be technical,
-legal, institutional, and political reasons to separate the authority over the
-original credential from the authority to revoke such a credential. Therefore,
-the `issuer` value of a <a>verifiable credential</a> containing a
-`BitstringStatusListEntry` MAY be different from the `issuer` value of a
-`BitstringStatusListCredential`.
+<a>verifiable credential</a> and the `issuer` of an associated
+`BitstringStatusListCredential` might not be the same. There are technical,
+legal, institutional, and political reasons that might make it appropriate
+to separate the authority over the original credential from the authority to
+revoke such a credential. Therefore, the `issuer` value of a <a>verifiable
+credential</a> containing a `BitstringStatusListEntry` MAY be different from
+the `issuer` value of a `BitstringStatusListCredential`.
       </p>
 
     </section>


### PR DESCRIPTION
This PR is an attempt to address issue #124 by explicitly noting that the `issuer` value for a `BitstringStatusListCredential` MAY be different from the `issuer` value of the associated VC.

/cc @jchartrand


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/129.html" title="Last updated on Jan 21, 2024, 11:09 PM UTC (32b32ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/129/3c87c08...32b32ca.html" title="Last updated on Jan 21, 2024, 11:09 PM UTC (32b32ca)">Diff</a>