### PR TITLE
Ensure better compression for `encodedList` by typing the value.

### DIFF
--- a/contexts/v1.jsonld
+++ b/contexts/v1.jsonld
@@ -14,8 +14,10 @@
 
         "statusPurpose":
           "https://www.w3.org/ns/credentials/status#statusPurpose",
-        "encodedList":
-          "https://www.w3.org/ns/credentials/status#encodedList",
+        "encodedList": {
+          "@id": "https://www.w3.org/ns/credentials/status#encodedList",
+          "@type": "https://w3id.org/security#multibase"
+        },
         "ttl": "https://www.w3.org/ns/credentials/status#ttl",
         "statusReference":
           "https://www.w3.org/ns/credentials/status#statusReference",

--- a/index.html
+++ b/index.html
@@ -587,16 +587,16 @@ specified when this `statusPurpose` value is used.
             <tr>
               <td id="encodedList">credentialSubject.encodedList</td>
               <td>
-The `encodedList` property of the credential <a>subject</a> MUST be
-the GZIP-compressed [[RFC1952]], base64url-encoded (with no padding) [[RFC4648]] bitstring values
-for the associated range of <a>verifiable credential</a> status values. The
-uncompressed bitstring MUST be at least 16KB in size. The bitstring MUST be
-encoded such that the first index, with a value of zero
-(`0`), is located at the left-most bit in the bitstring and the
-last index, with a value of one less than the length of the bitstring
-(`bitstring_length - 1`), is located at the right-most bit in the
-bitstring. Further information on bitstring encoding can be found in Section
-<a href="#bitstring-encoding"></a>.
+The `encodedList` property of the credential <a>subject</a> MUST be a
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase-encoded base64url (with
+no padding)</a> [[RFC4648]] representation of the GZIP-compressed [[RFC1952]]
+bitstring values for the associated range of <a>verifiable credential</a>
+status values. The uncompressed bitstring MUST be at least 16KB in size. The
+bitstring MUST be encoded such that the first index, with a value of zero (`0`),
+is located at the left-most bit in the bitstring and the last index, with a
+value of one less than the length of the bitstring (`bitstring_length - 1`), is
+located at the right-most bit in the bitstring. Further information on bitstring
+encoding can be found in Section <a href="#bitstring-encoding"></a>.
               </td>
             </tr>
             <tr>
@@ -681,7 +681,7 @@ a credential may involve some understanding of the business case involved.
     "id": "https://example.com/status/3#list",
     "type": "<span class="highlight">BitstringStatusList</span>",
     "statusPurpose": "<span class="highlight">revocation</span>",
-    "encodedList": "<span class="highlight">H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA</span>"
+    "encodedList": "<span class="highlight">uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA</span>"
   }
 }
         </pre>
@@ -715,7 +715,7 @@ implementation, privacy, and security standpoint.
         {"status":"0x2", "message":"pending_review"},
         ...
     ],
-    "encodedList": "H4sIAAAAAAAAA-3BMQEAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+    "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
   }
 }
         </pre>
@@ -1326,7 +1326,7 @@ data-vc-vm="https://example.edu/issuers/565049/keys/1">
     "id": "https://example.com/status/3#list",
     "type": "<span class="highlight">BitstringStatusList</span>",
     "statusPurpose": "<span class="highlight">revocation</span>",
-    "encodedList": "<span class="highlight">H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA</span>"
+    "encodedList": "<span class="highlight">uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA</span>"
   }
 }
 </pre>

--- a/vocab/vocabulary.yml
+++ b/vocab/vocabulary.yml
@@ -6,6 +6,9 @@ prefix:
   - id: cred
     value: https://w3.org/2018/credentials#
 
+  - id: sec
+    value: https://w3id.org/security#
+
 ontology:
   - property: dc:title
     value: Verifiable Credentials Bitstring Status List v1.0
@@ -54,7 +57,7 @@ property:
     label: Encoded list
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#encodedList
     domain: cs:BitstringStatusList
-    range: xsd:base64Binary
+    range: sec:multibase
 
   - id: ttl
     label: Time to live in milliseconds


### PR DESCRIPTION
This PR is an attempt to address issue #125 by strictly typing the `encodedList` value to ensure that it can be automatically converted to a pure binary value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/130.html" title="Last updated on Jan 21, 2024, 11:15 PM UTC (97b2010)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/130/fa75c28...97b2010.html" title="Last updated on Jan 21, 2024, 11:15 PM UTC (97b2010)">Diff</a>