### PR TITLE
added human readable/machine readable, changed example to be more clear.

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,7 +636,7 @@ If present, elements in the `statusMessage` array MUST contain at
 minimum two properties:
                 <ul>
                   <li id="status">
-`status`, being a machine readable string of the hex value of the status
+`status`, being a machine-readable string of the hex value of the status
                   </li>
                   <li id="message">
 `message`, being a human readable string containing the associated message

--- a/index.html
+++ b/index.html
@@ -710,9 +710,9 @@ implementation, privacy, and security standpoint.
     "statusReference": "https://example.org/status-dictionary/",
     "statusSize": 2,
     "statusMessage": [
-        {"status":"0x0", "message":"Valid"},
-        {"status":"0x1", "message":"Invalid"},
-        {"status":"0x2", "message":"Pending review"},
+        {"status":"0x0", "message":"valid"},
+        {"status":"0x1", "message":"invalid"},
+        {"status":"0x2", "message":"pending_review"},
         ...
     ],
     "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"

--- a/index.html
+++ b/index.html
@@ -639,7 +639,7 @@ minimum two properties:
 `status`, being a machine-readable string of the hex value of the status
                   </li>
                   <li id="message">
-`message`, being a human-readable string containing the associated message
+`message`, being an informative string to assist with debugging
                   </li>
                 </ul>
 Implementers MAY add additional values to objects in the `statusMessage` array.

--- a/index.html
+++ b/index.html
@@ -636,10 +636,10 @@ If present, elements in the `statusMessage` array MUST contain at
 minimum two properties:
                 <ul>
                   <li id="status">
-`status`, being a string of the hex value of the status
+`status`, being a machine readable string of the hex value of the status
                   </li>
                   <li id="message">
-`message`, being a string containing the associated message
+`message`, being a human readable string containing the associated message
                   </li>
                 </ul>
 Implementers MAY add additional values to objects in the `statusMessage` array.
@@ -710,9 +710,9 @@ implementation, privacy, and security standpoint.
     "statusReference": "https://example.org/status-dictionary/",
     "statusSize": 2,
     "statusMessage": [
-        {"status":"0x0", "message":"valid"},
-        {"status":"0x1", "message":"invalid"},
-        {"status":"0x2", "message":"pending_review"},
+        {"status":"0x0", "message":"Valid"},
+        {"status":"0x1", "message":"Invalid"},
+        {"status":"0x2", "message":"Pending review"},
         ...
     ],
     "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"

--- a/index.html
+++ b/index.html
@@ -639,7 +639,8 @@ minimum two properties:
 `status`, being a machine-readable string of the hex value of the status
                   </li>
                   <li id="message">
-`message`, being an informative string to assist with debugging
+`message`, being an informative string used by software developers to 
+assist with debugging which SHOULD NOT be displayed to end users.
                   </li>
                 </ul>
 Implementers MAY add additional values to objects in the `statusMessage` array.

--- a/index.html
+++ b/index.html
@@ -639,7 +639,7 @@ minimum two properties:
 `status`, being a machine-readable string of the hex value of the status
                   </li>
                   <li id="message">
-`message`, being a human readable string containing the associated message
+`message`, being a human-readable string containing the associated message
                   </li>
                 </ul>
 Implementers MAY add additional values to objects in the `statusMessage` array.


### PR DESCRIPTION
Status field should be machine readable, message should be human readable, I changed the example to make the message more clearly human readable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Mavennet/vc-bitstring-status-list/pull/138.html" title="Last updated on Apr 6, 2024, 7:10 PM UTC (86fd178)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/138/6c5f490...Mavennet:86fd178.html" title="Last updated on Apr 6, 2024, 7:10 PM UTC (86fd178)">Diff</a>