### PR TITLE
Update vocabulary and template files

### DIFF
--- a/vocab/template.html
+++ b/vocab/template.html
@@ -96,6 +96,10 @@
 		    text-align: center;
       }
 
+      summary {
+        font-weight: normal !important;
+      }
+
     </style>
   </head>
   <body  typeof="owl:Ontology">
@@ -135,25 +139,23 @@ archives</a>).
     <section>
       <h2>Specification of terms</h2>
       <p>
-In general, the terms &mdash; i.e., the properties and classes &mdash; used in
-the VCDM are formally specified in Recommendation Track documents published by
-the <a href="https://www.w3.org/groups/wg/vc">W3C Verifiable Credentials Working
-Group</a> or, for some deprecated or reserved terms, in Reports published by the
-<a href="https://www.w3.org/groups/cg/credentials">W3C Credentials Community
-Group</a>. In each case of such external definition, the term's description in
-this document contains a link to the relevant specification. Additionally, the
-`rdfs:definedBy` property in the RDFS representation(s) refers to the formal
-specification.
+        In general, the terms &mdash; i.e., the properties and classes &mdash; used in
+        the VCDM are formally specified in Recommendation Track documents published by
+        the <a href="https://www.w3.org/groups/wg/vc">W3C Verifiable Credentials Working
+        Group</a>. In each case of such external definition, the term's description in
+        this document contains a link to the relevant specification. Additionally, the
+        `rdfs:definedBy` property in the RDFS representation(s) refers to the formal
+        specification.
       </p>
       <p>
-In some cases, a local explanation is necessary to complement, or to replace,
-the definition found in an external specification. For instance, this is so when
-the term is needed to provide a consistent structure to the RDFS vocabulary,
-such as when the term defines a common supertype for class instances that are
-used as objects of specific properties. For such cases,
-the extra definition is included in the current
-document (and the `rdfs:comment` property is used to include them in the RDFS
-representations).
+        In some cases, a local explanation is necessary to complement, or to replace,
+        the definition found in an external specification. For instance, this is so when
+        the term is needed to provide a consistent structure to the RDFS vocabulary,
+        such as when the term defines a common supertype for class instances that are
+        used as objects of specific properties. For such cases,
+        the extra definition is included in the current
+        document (and the `rdfs:comment` property is used to include them in the RDFS
+        representations).
       </p>
     </section>
     <section>
@@ -163,15 +165,21 @@ representations).
       </dl>
     </section>
 
+    <section>
+      <h2><code>@context</code> files</h2>
+      <p>The following <code>@context</code> files make use of the terms defined in this specification:</p>
+      <ul id="contexts">
+      </ul>
+    </section>
+
     <section id="term_definitions">
       <h1>Regular terms</h1>
+      <section id="property_definitions" class="term_definitions">
+        <h2>Property definitions</h2>
+      </section>
 
       <section id="class_definitions" class="term_definitions">
         <h2>Class definitions</h2>
-      </section>
-
-      <section id="property_definitions" class="term_definitions">
-        <h2>Property definitions</h2>
       </section>
 
       <section id="datatype_definitions" class="term_definitions">
@@ -186,20 +194,17 @@ representations).
     <section id="deprecated_term_definitions">
       <h1>Deprecated terms</h1>
 
-      <p class="annoy">
-All terms in this section are <em><strong>deprecated</strong></em>, and are only
-kept in this vocabulary for backward compatibility.
+      <p class="annoy">All terms in this section are <em><strong>deprecated</strong></em>, and are only kept in this
+        vocabulary for backward compatibility.
+        <br><br>New applications should not use them.
       </p>
-      <p>
-New applications should not use them.
-      </p>
-
-      <section id="deprecated_class_definitions" class="term_definitions">
-        <h2>Deprecated classes</h2>
-      </section>
 
       <section id="deprecated_property_definitions" class="term_definitions">
         <h2>Deprecated properties</h2>
+      </section>
+
+      <section id="deprecated_class_definitions" class="term_definitions">
+        <h2>Deprecated classes</h2>
       </section>
 
       <section id="deprecated_property_definitions" class="term_definitions">

--- a/vocab/vocabulary.yml
+++ b/vocab/vocabulary.yml
@@ -1,6 +1,7 @@
 vocab:
   - id: cs
     value: https://www.w3.org/ns/credentials/status#
+    context: https://www.w3.org/ns/credentials/v2
 
 prefix:
   - id: cred
@@ -21,20 +22,16 @@ ontology:
 
 class:
   - id: BitstringStatusList
-    label: Bitstring status list
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslist
 
   - id: BitstringStatusListEntry
-    label: Bitstring status list entry
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistentry
 
   - id: BitstringStatusListCredential
-    label: Bitstring status list credential
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential
 
 property:
   - id: statusPurpose
-    label: Status purpose
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusPurpose
     domain:
       - cs:BitstringStatusList
@@ -42,19 +39,16 @@ property:
     range: xsd:string
 
   - id: statusListIndex
-    label: Status list index
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusListIndex
     domain: cs:BitstringStatusListEntry
     range: xsd:string
 
   - id: statusListCredential
-    label: Status list credential
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusListCredential
     domain: cs:BitstringStatusListEntry
     range: xsd:string
 
   - id: encodedList
-    label: Encoded list
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#encodedList
     domain: cs:BitstringStatusList
     range: sec:multibase
@@ -65,14 +59,13 @@ property:
     domain: cs:BitstringStatusList
     range: xsd:string
 
-  - id: size
+  - id: statusSize
     label: Bitstring entry size in bits
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusSize
     domain: cs:BitstringStatusList
     range: xsd:string
 
   - id: statusMessage
-    label: Status messages
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusMessage
     domain: cs:BitstringStatusList
     range: xsd:string
@@ -87,7 +80,7 @@ property:
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#message
     range: xsd:string
 
-  - id: reference
+  - id: statusReference
     label: Reference documentation for status messages
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusReference
     domain: cs:BitstringStatusList


### PR DESCRIPTION
yml2vocab has now the ability of adding information on designated @context files that contain individual terms to the output. This change is adapted to this vocabulary.

No changes on the vocabulary content itself.

As usual, the automatic preview is useless for this case, see https://w3c.github.io/yml2vocab/previews/sl/ for the new versions of the generated files.