### PR TITLE
Clarify internationalization mechanism for Processing Errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1013,8 +1013,8 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
         </li>
         <li>
 All human-readable strings SHOULD be localized as described in Section 1 of
-[[[RFC9457]]], using [=language negotiation=] on the `Accept-Language` HTTP
-header field to select the most appropriate resources.
+[[[RFC9457]]], using [=language negotiation=] through the `Accept-Language`
+HTTP header field to select the most appropriate resources.
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -990,7 +990,8 @@ by this specification might interoperate more effectively when errors occur.
 
       <p>
 When exposing these errors through an HTTP interface, implementers SHOULD use
-[[RFC9457]] to encode the error data structure. If [[RFC9457]] is used:
+[[[RFC9457]]] [[RFC9457]] to encode the error data structure. If [[RFC9457]] is
+used:
       </p>
 
       <ul>
@@ -1009,6 +1010,11 @@ the error.
         </li>
         <li>
 The `detail` value SHOULD provide a longer human-readable string for the error.
+        </li>
+        <li>
+All human-readable strings SHOULD support internationalization using
+the `Accept-Language` HTTP header field as described in Section 1 of
+[[[RFC9457]]].
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -1012,9 +1012,9 @@ the error.
 The `detail` value SHOULD provide a longer human-readable string for the error.
         </li>
         <li>
-All human-readable strings SHOULD support internationalization using
-the `Accept-Language` HTTP header field as described in Section 1 of
-[[[RFC9457]]].
+All human-readable strings SHOULD be localized as described in Section 1 of
+[[[RFC9457]]], using [=language negotiation=] on the `Accept-Language` HTTP
+header field to select the most appropriate resources.
         </li>
       </ul>
 


### PR DESCRIPTION
This PR is an attempt to address issue #140 by clarifying how internationalization support is provided for processing error messages.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/152.html" title="Last updated on Mar 30, 2024, 3:15 PM UTC (3c553d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/152/c28ea0a...3c553d0.html" title="Last updated on Mar 30, 2024, 3:15 PM UTC (3c553d0)">Diff</a>