### PR TITLE
Add normative statements related to caching of status list VCs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -803,9 +803,9 @@ endpoint listed in the <a>verifiable credential</a>.
       <p>
 [=Issuers=] SHOULD publish status list credentials in a way that can be cached
 and that does not track who retrieves the status list credential, such as
-through [[[?OHTTP]]], a content distribution network that is not operated by the
-[=issuer=], or by using business processes such that the access logs are not
-accessible to data analysts or systems administrators.
+through [[[RFC9458]]], a content distribution network that is not operated by
+the [=issuer=], or business processes for which the access logs are not
+accessible by data analysts or systems administrators.
       </p>
 
     </section>
@@ -916,8 +916,9 @@ validation rules permit such an action.
       </p>
 
       <p>
-[=Verifiers=] SHOULD cache the retrieval of the status list and SHOULD use
-proxies that hide retrieval behavior from the [=issuer=] such as [[[?OHTTP]]].
+[=Verifiers=] SHOULD cache the retrieved status list and SHOULD use proxies
+or other mechanisms, such as [[[RFC9458]]], that hide retrieval behavior from
+the [=issuer=].
       </p>
 
       <p class="note" title="Issuer validation is use case dependent">

--- a/index.html
+++ b/index.html
@@ -1078,14 +1078,6 @@ cryptographic parameters and the same media type for both
     <h2>Media Types</h2>
 
     <p>
-<a>Issuers</a> SHOULD publish status list information
-using HTTPS URLs and in ways that minimize possible correlation of usage
-patterns related to the list. <a>Verifiers</a>
-SHOULD retrieve status list information using protocols that guard against access
-pattern correlation, such as Oblivious HTTP [[?OHTTP]].
-    </p>
-
-    <p>
 When dereferencing `statusListCredential`, the content of the returned
 `statusListCredential` might be any media type registered for the purpose of
 expressing a verifiable credential with one or more proofs.

--- a/index.html
+++ b/index.html
@@ -799,6 +799,15 @@ Generate a proof for the |statusListCredential| and publish it to the
 endpoint listed in the <a>verifiable credential</a>.
         </li>
       </ol>
+
+      <p>
+[=Issuers=] SHOULD publish status list credentials in a way that can be cached
+and that does not track who retrieves the status list credential, such as
+through [[[?OHTTP]]], a content distribution network that is not operated by the
+[=issuer=], or by using business processes such that the access logs are not
+accessible to data analysts or systems administrators.
+      </p>
+
     </section>
 
     <section class="normative">
@@ -904,6 +913,11 @@ the status list as it existed at the given point in time, or a
 an error, implementations MAY attempt the retrieval again with a different
 timestamp value, or without a timestamp value, as long as the <a>verifier</a>'s
 validation rules permit such an action.
+      </p>
+
+      <p>
+[=Verifiers=] SHOULD cache the retrieval of the status list and SHOULD use
+proxies that hide retrieval behavior from the [=issuer=] such as [[[?OHTTP]]].
       </p>
 
       <p class="note" title="Issuer validation is use case dependent">


### PR DESCRIPTION
This PR is an attempt to address issue #144 and #145 by providing normative guidance to both issuers and verifiers on publishing, retrieval, and caching behaviour.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/153.html" title="Last updated on Mar 30, 2024, 3:23 PM UTC (8510cc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/153/8287319...8510cc4.html" title="Last updated on Mar 30, 2024, 3:23 PM UTC (8510cc4)">Diff</a>