### PR TITLE
Clarify normative text around randomness of list index.

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,9 +405,9 @@ Used to convey an arbitrary message related to the status of the
 The `statusListIndex` property MUST be an arbitrary size integer
 greater than or equal to 0, expressed as a string in base 10. The value identifies the
 position of the status of the <a>verifiable credential</a>. Implementations
-SHOULD assign indexes randomly such that inferences cannot be easily drawn
-from the position such as the recency of the assignment or the size of the
-group.
+SHOULD assign indexes randomly, such that inferences — such as the recency
+of the assignment or the size of the group — cannot be easily drawn from
+that position.
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -405,7 +405,9 @@ Used to convey an arbitrary message related to the status of the
 The `statusListIndex` property MUST be an arbitrary size integer
 greater than or equal to 0, expressed as a string in base 10. The value identifies the
 position of the status of the <a>verifiable credential</a>. Implementations
-SHOULD assign indexes randomly.
+SHOULD assign indexes randomly such that inferences cannot be easily drawn
+from the position such as the recency of the assignment or the size of the
+group.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This PR is an attempt to address issue #149 by being more specific about the randomization requirements for the status list index.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/154.html" title="Last updated on Mar 30, 2024, 6:22 PM UTC (c0bb5e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/154/c28ea0a...c0bb5e1.html" title="Last updated on Mar 30, 2024, 6:22 PM UTC (c0bb5e1)">Diff</a>