### PR TITLE
Added changes to the vocabulary per #158

### DIFF
--- a/vocab/template.html
+++ b/vocab/template.html
@@ -157,6 +157,16 @@ archives</a>).
         document (and the `rdfs:comment` property is used to include them in the RDFS
         representations).
       </p>
+      <figure id="vocabulary-diagram" style="text-align:center">
+        <div data-include="vocabulary.svg" data-include-replace="true" data-oninclude="massageSVGLinks"></div>
+        <figcaption>Overview diagram of the vocabulary (without the`xsd`
+          datatypes). The terms prefixed by <code>cred:</code> or <code>sec:</code> are not defined in this vocabulary;
+          they have only been added to the diagram for the sake of clarity.<br />
+          A separate, stand-alone <a href="vocabulary.svg" target="_blank">SVG version</a> of the diagram, as well as a <a
+            href="#vocabulary-diagram-alt">textual description</a>,
+          are also available.
+        </figcaption>
+      </figure>
     </section>
     <section>
       <h2>Namespaces</h2>
@@ -215,6 +225,105 @@ archives</a>).
         <h2>Deprecated individuals</h2>
       </section>
     </section>
+
+    <section class="appendix" id="vocabulary-diagram-alt">
+      <h2>Diagram description</h2>
+      <details>
+        <summary>Overview diagram of the vocabulary (without the `xsd` datatypes). The terms prefixed by <code>cred:</code> or
+        <code>sec:</code> are not defined in this vocabulary; they have only been added to the diagram for the sake of clarity.</summary>
+        <p>
+          The diagram uses boxes, ellipses, and connecting lines with different "styles"
+          (border color, end marker, line type) to differentiate their semantic meaning:
+          "Property", "Class", and "Datatype" are identified by the shape of the
+          graph node (e.g., an ellipse signifies a "Class"); "Superclass", "Domain Of", or "Range" relationships 
+          are identified by the style of the connecting line.
+          These style names are used in the explanation text that follows, below.
+        </p>
+        <p>
+          The diagram is roughly divided into three sections — left, middle, and right.
+          To make this description easier to understand, these sections will be respectively referred to
+          as the "Classes", "Properties", and "Values" sections.
+          Shapes in the three sections are connected by lines of different styles.
+        </p>
+        <section>
+          <h3>Classes Section</h3>
+
+          <p>
+            The section contains three ellipses, labeled as "cred:CredentialStatus",
+            "BitstringStatusListEntry", and "BitstringStatusList". It also contains
+            a box, styled as "Property" and labeled as "cred:credentialStatus".
+          </p>
+
+          <p>
+            The "cred:CredentialStatus" ellipse, is connected to the ellipse, 
+            labeled as "cred:CredentialStatus", with a line styled "Range". 
+            The ellipse labeled as "BitstringStatusListEntry" is connected to the 
+            ellipse, labeled as "cred:CredentialStatus", with a line styled as 
+            "Superclass".
+          </p>
+
+          <p>
+            The ellipses labeled as "BitstringStatusListEntry" and "BitstringStatusList" are 
+            also connected to a number of boxes, all styled as "Property", with lines styled as
+            "Domain Of"; see the "Properties" section below for further details.
+          </p>
+        </section>
+        <section>
+          <h3>Properties Section</h3>
+
+          <p>
+            The section contains a number of boxes, each styles as "Property". The labels of 
+            these boxes are "statusListIndex", "statusListCredential", "statusPurpose", 
+            "statusMessage", "ttl", "statusReference", "statusSize", and "encodedList".
+            There is also a small, unlabeled circle, which serves as an intersection point for connector
+            lines.
+          </p>
+
+          <p>
+            The ellipse labeled as "BitstringStatusListEntry", described in the previous section, is 
+            connected to the "statusListIndex", and "statusListCredential" boxes with lines styled as "Domain Of". 
+            The ellipse labeled as "BitstringStatusList", also described in the previous section, 
+            is connected to the "statusMessage", "ttl", "statusReference", "statusSize", 
+            and "encodedList" boxes, also with lines styled as "Domain Of".
+          </p>
+
+          <p>
+            Both the ellipses labeled as "BitstringStatusListEntry" and "BitstringStatusList" are connected to the 
+            intersection point with a line styled as "Domain Of", and the intersection point is connected to the 
+            box labeled as "statusPurpose with a line styled as "Domain Of".
+          </p>
+        </section>
+        <section>
+          <h3>Values Section</h3>
+
+          <p>
+            The section contains and ellipse, labeled as "BitstringStatusListCredential", which is connected to 
+            another ellipse, labeled as "cred:VerifiableCredential", with a line styled as "Superclass". 
+            The box labeled as "statusListCredential", described in the previous section, is connected to the ellipse, 
+            labeled as "BitstringStatusListCredential", with a line styled as "Range".
+          </p>
+
+          <p>
+            Another ellipse, labeled as "BistringStatusMessage", is connected to two boxes with lines styled 
+            as "Domain Of". The boxes are styled as "Property" and are labeled with "status" and "message". 
+            The box labeled as "statusMessage", described in the previous section, is connected to the ellipse,
+            labeled as "BistringStatusMessage", with a line styled as "Range".
+          </p>
+
+          <p>
+            The box labeled as "statusSize", described in the previous section, is connected to a box, styled 
+            as "Datatype", and labeled as "xsd:positiveInteger", with a line styled as "Range".
+          </p>
+
+          <p>
+            The box labeled as "encodedList", described in the previous section, is connected to a box, styled
+            as "Datatype", and labeled as "sec:multibase", with a line styled as "Range".
+          </p>
+        </section>
+     </details>
+    </section>
+
+
 
 </body>
 </html>

--- a/vocab/vocabulary.drawio
+++ b/vocab/vocabulary.drawio
@@ -1,0 +1,330 @@
+<mxfile host="Electron" modified="2024-03-29T09:30:15.894Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.1.0 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="jvZk6pBkTdtMdDo_x32J" version="24.1.0" type="device">
+  <diagram name="Page-1" id="5wcF2D67hh1iBqyEtvuE">
+    <mxGraphModel dx="3232" dy="2133" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;cred:VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-320" y="-817.0023160061761" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-35" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-1388.5" y="-60" width="1198" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-5" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1">
+          <mxGeometry width="1198" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-6" value="" style="group" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1" connectable="0">
+          <mxGeometry x="432" y="7.639812500000005" width="163.39999999999998" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="" id="jcIRoWpeUHbpSJrjuQO4-7">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-6" vertex="1">
+            <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-8" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="jcIRoWpeUHbpSJrjuQO4-6" vertex="1">
+          <mxGeometry x="13" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-9" value="" style="group" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1" connectable="0">
+          <mxGeometry x="230" y="9.077312500000005" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-9" vertex="1">
+          <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-11" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-9" vertex="1">
+          <mxGeometry width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-12" value="" style="group" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1" connectable="0">
+          <mxGeometry x="627" y="9.074812500000007" width="169" height="37.13" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-13" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="86.48823529411764" y="17.94616666666667" as="sourcePoint" />
+            <mxPoint x="166.01764705882354" y="18.565" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-14" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-12" vertex="1">
+          <mxGeometry x="-4.970588235294118" width="80" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-15" value="" style="group" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1" connectable="0">
+          <mxGeometry x="842" y="9.077312500000005" width="136" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=5 2 2 2;" parent="jcIRoWpeUHbpSJrjuQO4-15" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="74" y="18.5625" as="sourcePoint" />
+            <mxPoint x="154" y="18.5625" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="130" y="18.5625" />
+              <mxPoint x="130" y="18.5625" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-17" value="Domain&lt;br&gt;of" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-15" vertex="1">
+          <mxGeometry y="-5" width="60" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-18" value="" style="group" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1" connectable="0">
+          <mxGeometry x="1028" y="9.077312500000005" width="160" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-18" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="67" y="18.5625" as="sourcePoint" />
+            <mxPoint x="147" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-20" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-18" vertex="1">
+          <mxGeometry width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-27" value="" style="group" parent="trhtjT2bqsuKHk80iaI0-35" vertex="1" connectable="0">
+          <mxGeometry x="7" y="12.639812500000005" width="160" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-28" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-27" vertex="1">
+          <mxGeometry x="60" y="0.9976874999999996" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-29" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-27" vertex="1">
+          <mxGeometry width="50" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-9" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="trhtjT2bqsuKHk80iaI0-1" target="lZdwYr-LXM3OhQDUA7XR-34" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1447" y="-745.9536798764798" as="sourcePoint" />
+            <mxPoint x="-1480" y="-580.2897581060216" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-13" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1360.5" y="-282.29545548121473" as="sourcePoint" />
+            <mxPoint x="-1360.5" y="-282.29545548121473" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;BitstringStatusList&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#BitstringStatusList" id="1oUjKqBKF74gJ-cnWfdO-15">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1388.5" y="-293.2157436953165" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;statusPurpose&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#statusPurpose" id="lZdwYr-LXM3OhQDUA7XR-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-509" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fontSize=16;fillColor=#cc0000;strokeColor=none;" parent="1" vertex="1">
+          <mxGeometry x="-1080" y="-500.39" width="10" height="10" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-23" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="trhtjT2bqsuKHk80iaI0-1" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1171" y="-127.71756562017481" as="sourcePoint" />
+            <mxPoint x="-1048" y="-100.10447761194041" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-24" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-856" y="-92.10138960370568" as="sourcePoint" />
+            <mxPoint x="-1055" y="-284" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-25" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-924" y="-284.57565620175" as="sourcePoint" />
+            <mxPoint x="-876" y="-221.39475038600108" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;cred:CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1388.5" y="-817.0023160061761" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-37" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="trhtjT2bqsuKHk80iaI0-5" target="trhtjT2bqsuKHk80iaI0-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-710" y="-117.00475038600109" as="sourcePoint" />
+            <mxPoint x="-591.0000000000059" y="-117.00475038600109" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-41" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="trhtjT2bqsuKHk80iaI0-6" target="NdHKz3nYJsEpI_Vai11b-4" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1080" y="-71.07475038600114" as="sourcePoint" />
+            <mxPoint x="-961.0000000000059" y="-71.07475038600114" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;font color=&quot;#000000&quot;&gt;xsd:positiveInteger&lt;/font&gt;" id="usrDyYZYH79wCYu34c_K-9">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-550.185" y="-212.749750386001" width="158.37" height="28.71" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font color=&quot;#000000&quot;&gt;sec:multibase&lt;/font&gt;" link="https://w3id.org/security#multibase" id="NdHKz3nYJsEpI_Vai11b-4">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-550.185" y="-138.74975038600104" width="158.37" height="28.71" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;BitstringStatusListEntry&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#BitstringStatusListEntry" id="trhtjT2bqsuKHk80iaI0-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1388.5" y="-622.212316006176" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;BitstringStatusListCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#BitstringStatusListCredential" id="trhtjT2bqsuKHk80iaI0-2">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-586" y="-589" width="230" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-3" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="trhtjT2bqsuKHk80iaI0-2" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1210.5" y="-541.6" as="sourcePoint" />
+            <mxPoint x="-1251.5" y="-731.6" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-260" y="-657" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;statusListIndex&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#statusListIndex" id="trhtjT2bqsuKHk80iaI0-4">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-657" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;statusListCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#statusListCredential" id="trhtjT2bqsuKHk80iaI0-5">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-583" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;encodedList&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#encodedList" id="trhtjT2bqsuKHk80iaI0-6">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-138" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ttl&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#ttl" id="trhtjT2bqsuKHk80iaI0-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-360" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;statusSize&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#statusSize" id="trhtjT2bqsuKHk80iaI0-8">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-212" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;statusMessage&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#statusMessage" id="trhtjT2bqsuKHk80iaI0-9">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-435" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;statusReference&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#statusReference" id="trhtjT2bqsuKHk80iaI0-12">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;flipV=0;" parent="1" vertex="1">
+            <mxGeometry x="-940" y="-286" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="trhtjT2bqsuKHk80iaI0-1" target="trhtjT2bqsuKHk80iaI0-4" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1241" y="-240" as="sourcePoint" />
+            <mxPoint x="-1053" y="-291" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1060" y="-637" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-17" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="trhtjT2bqsuKHk80iaI0-1" target="trhtjT2bqsuKHk80iaI0-5" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1241" y="-240" as="sourcePoint" />
+            <mxPoint x="-920" y="-206" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1060" y="-577" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="trhtjT2bqsuKHk80iaI0-6" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1272" y="-226" as="sourcePoint" />
+            <mxPoint x="-961" y="-153" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1070" y="-177" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-20" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="trhtjT2bqsuKHk80iaI0-7" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1260.0021327569584" y="-467.4029439248462" as="sourcePoint" />
+            <mxPoint x="-1030.78" y="-347.37" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1050" y="-327" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-23" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="trhtjT2bqsuKHk80iaI0-8" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1240" y="-417" as="sourcePoint" />
+            <mxPoint x="-1124" y="-619" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1060" y="-217" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-24" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="trhtjT2bqsuKHk80iaI0-8" target="usrDyYZYH79wCYu34c_K-9" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-695" y="-381.3947503860011" as="sourcePoint" />
+            <mxPoint x="-840" y="-617" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-25" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="trhtjT2bqsuKHk80iaI0-31" target="trhtjT2bqsuKHk80iaI0-11" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1272" y="-411" as="sourcePoint" />
+            <mxPoint x="-1124" y="-619" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-300" y="-387" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="trhtjT2bqsuKHk80iaI0-31" target="trhtjT2bqsuKHk80iaI0-10" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1368" y="-479.79" as="sourcePoint" />
+            <mxPoint x="-1220" y="-687.79" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-300" y="-457" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-28" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="trhtjT2bqsuKHk80iaI0-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1272" y="-411" as="sourcePoint" />
+            <mxPoint x="-1196" y="-740" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-30" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="trhtjT2bqsuKHk80iaI0-9" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1272" y="-411" as="sourcePoint" />
+            <mxPoint x="-1196" y="-740" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1070" y="-377" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;BitstringStatusMessage&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#BitstringStatusMessage" id="trhtjT2bqsuKHk80iaI0-31">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-580" y="-440.9976119402986" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-32" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="trhtjT2bqsuKHk80iaI0-9" target="trhtjT2bqsuKHk80iaI0-31" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-961" y="-456" as="sourcePoint" />
+            <mxPoint x="-820" y="-605" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;cred:credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials#credentialStatus" id="trhtjT2bqsuKHk80iaI0-40">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-1580" y="-897.0000000000001" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="trhtjT2bqsuKHk80iaI0-41" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;entryX=0;entryY=0;entryDx=0;entryDy=0;" parent="1" source="trhtjT2bqsuKHk80iaI0-40" target="lZdwYr-LXM3OhQDUA7XR-34" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1454" y="-376" as="sourcePoint" />
+            <mxPoint x="-1519" y="-424" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;status&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#status" id="trhtjT2bqsuKHk80iaI0-10">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-220" y="-489.9952959341226" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;message&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/ns/credentials/status#message" id="trhtjT2bqsuKHk80iaI0-11">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-220" y="-379.99529593412274" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/vocab/vocabulary.svg
+++ b/vocab/vocabulary.svg
@@ -1,0 +1,539 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-0.5 -0.5 1573 933">
+    <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredential">
+        <ellipse cx="1390" cy="120.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:121px;margin-left:1282px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    cred:VerifiableCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1390" y="125" font-family="Helvetica" font-size="16" text-anchor="middle">cred:VerifiableCredential</text>
+        </switch>
+    </a>
+    <rect width="1198" height="54.5" x="212.5" y="858" fill="none"/>
+    <rect width="1198" height="54.5" x="212.5" y="858" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
+    <rect width="163.4" height="40" x="644.5" y="865.64" fill="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M739.5 877.14h48.4l20 8.5-20 8.5h-48.4l-20-8.5Z" pointer-events="all"/>
+    <rect width="90" height="40" x="657.5" y="865.64" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:873px;margin-left:660px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
+                            Datatype
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="660" y="889" font-family="Helvetica" font-size="16">Datatype</text>
+    </switch>
+    <rect width="170" height="37.13" x="442.5" y="867.08" fill="none"/>
+    <rect width="80" height="23.69" x="525.5" y="872.03" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
+    <rect width="70" height="30" x="442.5" y="867.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:882px;margin-left:478px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Property
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="478" y="886" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
+    </switch>
+    <rect width="169" height="37.13" x="839.5" y="867.07" fill="none"/>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m925.99 885.02 71.29.56" pointer-events="stroke"/>
+        <path d="m1003.28 885.62-8.03 3.94 2.03-3.98-1.97-4.02Z" pointer-events="all"/>
+    </g>
+    <rect width="80" height="30" x="834.53" y="867.07" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:882px;margin-left:875px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Superclass
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="875" y="886" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
+    </switch>
+    <rect width="136" height="37.13" x="1054.5" y="867.08" fill="none"/>
+    <g stroke="#f33" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="m1128.5 885.64 56-.04 15.76.03" pointer-events="stroke"/>
+        <path fill="#f33" d="m1206.26 885.64-8 3.98 2-3.99-1.99-4.01Z" pointer-events="all"/>
+    </g>
+    <rect width="60" height="40" x="1054.5" y="862.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:882px;margin-left:1085px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Domain
+                        <br/>
+                        of
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1085" y="886" font-family="Helvetica" font-size="12" text-anchor="middle">Domain...</text>
+    </switch>
+    <rect width="160" height="37.13" x="1240.5" y="867.08" fill="none"/>
+    <g stroke="#00c" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1307.5 885.64h71.76" pointer-events="stroke"/>
+        <path fill="#00c" d="m1385.26 885.64-8 4 2-4-2-4Z" pointer-events="all"/>
+    </g>
+    <rect width="60" height="30" x="1240.5" y="867.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:882px;margin-left:1271px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Range
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1271" y="886" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
+    </switch>
+    <rect width="160" height="30" x="219.5" y="870.64" fill="none"/>
+    <ellipse cx="329.5" cy="885.64" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="50" height="30" x="219.5" y="870.64" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:886px;margin-left:245px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Class
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="245" y="889" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M321.5 295.79V149.95" pointer-events="stroke"/>
+        <path d="m321.5 142.45 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#BitstringStatusList">
+        <ellipse cx="321.5" cy="644.39" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:644px;margin-left:214px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    BitstringStatusList
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="322" y="649" font-family="Helvetica" font-size="16" text-anchor="middle">BitstringStatusList</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#statusPurpose">
+        <rect width="171" height="27.21" x="661" y="409" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:423px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    statusPurpose
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="427" font-family="Helvetica" font-size="16" text-anchor="middle">statusPurpose</text>
+        </switch>
+    </a>
+    <circle cx="526" cy="422.61" r="5" fill="#c00" pointer-events="all"/>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="m430.5 315.4 89.19 104.8" pointer-events="stroke"/>
+        <path fill="#c00" d="m524.55 425.91-10.29-4.38 5.43-1.33 2.19-5.15Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="m430.5 644.39 91.72-217.81" pointer-events="stroke"/>
+        <path fill="#c00" d="m525.13 419.67.73 11.16-3.64-4.25-5.58.37Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M531 422.61h120.26" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.76 422.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://www.w3.org/2018/credentials#CredentialStatus">
+        <ellipse cx="321.5" cy="120.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:121px;margin-left:214px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    cred:CredentialStatus
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="322" y="125" font-family="Helvetica" font-size="16" text-anchor="middle">cred:CredentialStatus</text>
+        </switch>
+    </a>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M832 348.61h173.26" pointer-events="stroke"/>
+        <path fill="#009" d="m1012.76 348.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M832 793.61h209.08" pointer-events="stroke"/>
+        <path fill="#009" d="m1048.58 793.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1070.82 705.25h118.36l20 14.36-20 14.35h-118.36l-20-14.35Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:156px;height:1px;padding-top:720px;margin-left:1052px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font color="#000">
+                            xsd:positiveInteger
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1130" y="724" font-family="Helvetica" font-size="16" text-anchor="middle">xsd:positiveInteger</text>
+    </switch>
+    <a xlink:href="https://w3id.org/security#multibase">
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1070.82 779.25h118.36l20 14.36-20 14.35h-118.36l-20-14.35Z" pointer-events="all"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:156px;height:1px;padding-top:794px;margin-left:1052px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <font color="#000">
+                                sec:multibase
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1130" y="798" font-family="Helvetica" font-size="16" text-anchor="middle">sec:multibase</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#BitstringStatusListEntry">
+        <ellipse cx="321.5" cy="315.4" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:315px;margin-left:214px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    BitstringStatusListEntry
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="322" y="320" font-family="Helvetica" font-size="16" text-anchor="middle">BitstringStatusListEntry</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#BitstringStatusListCredential">
+        <ellipse cx="1130" cy="348.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="115" ry="19.61"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:228px;height:1px;padding-top:349px;margin-left:1016px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    BitstringStatusListCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1130" y="353" font-family="Helvetica" font-size="16" text-anchor="middle">BitstringStatusListCredential</text>
+        </switch>
+    </a>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M1245 348.61q96-87.61 141.34-199.38" pointer-events="stroke"/>
+        <path d="m1389.16 142.28.87 11.15-3.69-4.2-5.57.44Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#statusListIndex">
+        <rect width="171" height="27.21" x="661" y="261" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:275px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    statusListIndex
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="279" font-family="Helvetica" font-size="16" text-anchor="middle">statusListIndex</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#statusListCredential">
+        <rect width="171" height="27.21" x="661" y="335" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:349px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    statusListCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="353" font-family="Helvetica" font-size="16" text-anchor="middle">statusListCredential</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#encodedList">
+        <rect width="171" height="27.21" x="661" y="780" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:794px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    encodedList
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="798" font-family="Helvetica" font-size="16" text-anchor="middle">encodedList</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#ttl">
+        <rect width="171" height="27.21" x="661" y="558" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:572px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    ttl
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="576" font-family="Helvetica" font-size="16" text-anchor="middle">ttl</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#statusSize">
+        <rect width="171" height="27.21" x="661" y="706" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:720px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    statusSize
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="724" font-family="Helvetica" font-size="16" text-anchor="middle">statusSize</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#statusMessage">
+        <rect width="171" height="27.21" x="661" y="483" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:497px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    statusMessage
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="501" font-family="Helvetica" font-size="16" text-anchor="middle">statusMessage</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#statusReference">
+        <rect width="171" height="27.21" x="661" y="632" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:646px;margin-left:662px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    statusReference
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="747" y="650" font-family="Helvetica" font-size="16" text-anchor="middle">statusReference</text>
+        </switch>
+    </a>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M430.5 315.4Q541 281 651.28 275.12" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.77 274.72-9.72 5.53 2.23-5.13-2.76-4.86Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M430.5 315.4Q541 341 651.28 347.99" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.77 348.46-10.3 4.36 2.81-4.83-2.18-5.15Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M430.5 644.39Q531 741 651.97 789.95" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.93 792.77-11.15.88 4.19-3.7-.44-5.57Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M430.5 644.39Q551 591 651.41 573.3" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.8 571.99-8.98 6.66 1.59-5.35-3.33-4.49Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M430.5 644.39Q541 701 651.38 718.11" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.79 719.26-10.65 3.41 3.24-4.56-1.71-5.32Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M832 719.61h209.08" pointer-events="stroke"/>
+        <path fill="#009" d="m1048.58 719.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M1239 496.61q62 34.39 132.57 52.57" pointer-events="stroke"/>
+        <path fill="#c00" d="m1378.83 551.05-10.93 2.35 3.67-4.22-1.17-5.46Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M1239 496.61q62-35.61 132.54-52.71" pointer-events="stroke"/>
+        <path fill="#c00" d="m1378.83 442.14-8.54 7.21 1.25-5.45-3.61-4.27Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="m430.5 644.39 220.76 1.16" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.76 645.59-10.02 4.95 2.52-4.99-2.47-5.01Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="10 4 4 4" d="M430.5 644.39Q531 541 651.79 499.75" pointer-events="stroke"/>
+        <path fill="#c00" d="m658.88 497.33-7.84 7.96.75-5.54-3.99-3.92Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#BitstringStatusMessage">
+        <ellipse cx="1130" cy="496.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:497px;margin-left:1022px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    BitstringStatusMessage
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1130" y="501" font-family="Helvetica" font-size="16" text-anchor="middle">BitstringStatusMessage</text>
+        </switch>
+    </a>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M832 496.61h179.26" pointer-events="stroke"/>
+        <path fill="#009" d="m1018.76 496.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://www.w3.org/ns/credentials#credentialStatus">
+        <rect width="171" height="27.21" x="21" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:35px;margin-left:22px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    cred:credentialStatus
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="107" y="39" font-family="Helvetica" font-size="16" text-anchor="middle">cred:credentialStatus</text>
+        </switch>
+    </a>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="m106.5 48.21 127.78 54.91" pointer-events="stroke"/>
+        <path fill="#009" d="m241.17 106.08-11.16.64 4.27-3.6-.33-5.58Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#status">
+        <rect width="171" height="27.21" x="1381" y="428" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:442px;margin-left:1382px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    status
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1467" y="446" font-family="Helvetica" font-size="16" text-anchor="middle">status</text>
+        </switch>
+    </a>
+    <a xlink:href="https://www.w3.org/ns/credentials/status#message">
+        <rect width="171" height="27.21" x="1381" y="538" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:552px;margin-left:1382px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    message
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1467" y="556" font-family="Helvetica" font-size="16" text-anchor="middle">message</text>
+        </switch>
+    </a>
+</svg>

--- a/vocab/vocabulary.yml
+++ b/vocab/vocabulary.yml
@@ -12,7 +12,7 @@ prefix:
 
 ontology:
   - property: dc:title
-    value: Verifiable Credentials Bitstring Status List v1.0
+    value: Bitstring Status List Vocabulary
 
   - property: dc:description
     value: RDFS [[RDF-SCHEMA]] vocabulary used by the [[[VC-BITSTRING-STATUS-LIST]]] [[VC-BITSTRING-STATUS-LIST]]
@@ -25,10 +25,15 @@ class:
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslist
 
   - id: BitstringStatusListEntry
+    upper_value: cred:CredentialStatus
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistentry
 
   - id: BitstringStatusListCredential
+    upper_value: cred:VerifiableCredential
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential
+
+  - id: BitstringStatusMessage
+    defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusMessage
 
 property:
   - id: statusPurpose
@@ -46,7 +51,7 @@ property:
   - id: statusListCredential
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusListCredential
     domain: cs:BitstringStatusListEntry
-    range: xsd:string
+    range: cs:BitstringStatusListCredential
 
   - id: encodedList
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#encodedList
@@ -63,25 +68,27 @@ property:
     label: Bitstring entry size in bits
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusSize
     domain: cs:BitstringStatusList
-    range: xsd:string
+    range: xsd:positiveInteger
 
   - id: statusMessage
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusMessage
     domain: cs:BitstringStatusList
-    range: xsd:string
+    range: cs:BitstringStatusMessage
 
   - id: status
     label: Hexadecimal value of a status message
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#status
     range: xsd:string
+    domain: cs:BitstringStatusMessage
 
   - id: message
     label: Human-readable message of a status value
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#message
     range: xsd:string
+    domain: cs:BitstringStatusMessage
 
   - id: statusReference
     label: Reference documentation for status messages
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusReference
     domain: cs:BitstringStatusList
-    range: xsd:string
+    range: URL


### PR DESCRIPTION
This PR implements the changes proposed in #158, adds a diagram (with its textual description) to the generated HTML+RDFa file to be in line in style with the other vocabularies.

As usual, the built-in preview would not help for the generated vocabulary files and the diagrams. The preview page to be used is here: https://w3c.github.io/yml2vocab/previews/sl/