### PR TITLE
Add Privacy Considerations section on "Unnecessary Correlation".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1144,33 +1144,32 @@ to correlate [=subjects=]. Some of these properties include `id`,
       </p>
 
       <p>
-In some cases, when [=presenting=] a [=verifiable credential=] that contains
-other global identifiers (such as a driver's license identification number),
-using other global identifiers for the status list information does not cause
-further correlation harms since the only thing required for correlation is a
-single globally unique identifier.
+In some cases, such as when [=presenting=] a [=verifiable credential=] that
+contains any other global identifier (such as a driver's license identification
+number), adding one or more global identifier(s) for the status list information
+does not increase correlation harm, since a single globally unique identifier is
+all that is required for correlation.
       </p>
 
       <p>
-When these global identifiers are used in [=presentations=] that utilize
+When global identifiers are used in [=presentations=] that use
 [=selective disclosure=] or [=unlinkable disclosure=], they can violate privacy
 expectations. [=Issuers=] are urged to enable status information to be
-selectively disclosable when there is an expectation that a particular
-[=verifiable credential=] can be disclosed in a way that avoids
-correlation, such as proving that an individual is above a certain age.
-[=Verifiers=] can require that status information is revealed in situations that
-require them to know the current status of a credential, and the holder might
-then consent to revealing that information or might refuse to do so for a given
-transaction. In all cases, both [=issuers=] and [=verifiers=] are urged to
-ensure that the use of global identifiers is avoided when a particular exchange
-does not require correlation.
+selectively disclosable/concealable when a particular [=verifiable credential=]
+is expected to be disclosed in a way that doesn't need correlation, such as when
+proving that an individual is above a certain age. [=Verifiers=] can require
+that status information be revealed in situations that require them to know the
+current status of a credential, and the holder might then consent or refuse to
+reveal that information for a given transaction. In all cases, both [=issuers=]
+and [=verifiers=] are urged to avoid the use of global identifiers in order to
+prevent correlation, unless it is required for or by a particular exchange.
       </p>
 
       <p>
-For more information on other types of correlation that is possible,
-readers are urged to read the Privacy Considerations section
-in the [[[VC-DATA-MODEL-2.0]]] specification, specifically the
-sections on <a data-cite="VC-DATA-MODEL-2.0#identifier-based-correlation">
+For information on other types of potential correlation,
+readers are urged to digest the Privacy Considerations section of the
+[[[VC-DATA-MODEL-2.0]]] specification, particularly the subsections on
+<a data-cite="VC-DATA-MODEL-2.0#identifier-based-correlation">
 Identifier-Based Correlation</a>,
 <a data-cite="VC-DATA-MODEL-2.0#signature-based-correlation">
 Signature-Based Correlation</a>,

--- a/index.html
+++ b/index.html
@@ -1134,6 +1134,55 @@ that have received a credential from the same geographic region.
     </section>
 
     <section class="informative">
+      <h3>Unnecessary Correlation</h3>
+
+      <p>
+There are a number of global identifiers used in a status list entry, defined in
+Section [[[#bitstringstatuslistentry]]], that can be used across [=verifiers=]
+to correlate [=subjects=]. Some of these properties include `id`,
+`statusListIndex`, and `statusListCredential`.
+      </p>
+
+      <p>
+In some cases, when [=presenting=] a [=verifiable credential=] that contains
+other global identifiers (such as a driver's license identification number),
+using other global identifiers for the status list information does not cause
+further correlation harms since the only thing required for correlation is a
+single globally unique identifier.
+      </p>
+
+      <p>
+When these global identifiers are used in [=presentations=] that utilize
+[=selective disclosure=] or [=unlinkable disclosure=], they can violate privacy
+expectations. [=Issuers=] are urged to enable status information to be
+selectively disclosable when there is an expectation that a particular
+[=verifiable credential=] can be disclosed in a way that avoids
+correlation, such as proving that an individual is above a certain age.
+[=Verifiers=] can require that status information is revealed in situations that
+require them to know the current status of a credential, and the holder might
+then consent to revealing that information or might refuse to do so for a given
+transaction. In all cases, both [=issuers=] and [=verifiers=] are urged to
+ensure that the use of global identifiers is avoided when a particular exchange
+does not require correlation.
+      </p>
+
+      <p>
+For more information on other types of correlation that is possible,
+readers are urged to read the Privacy Considerations section
+in the [[[VC-DATA-MODEL-2.0]]] specification, specifically the
+sections on <a data-cite="VC-DATA-MODEL-2.0#identifier-based-correlation">
+Identifier-Based Correlation</a>,
+<a data-cite="VC-DATA-MODEL-2.0#signature-based-correlation">
+Signature-Based Correlation</a>,
+<a data-cite="VC-DATA-MODEL-2.0#long-lived-identifier-based-correlation">
+Long-Lived Identifier-Based Correlation</a>, and
+<a data-cite="VC-DATA-MODEL-2.0#metadata-based-correlation">
+Metadata-Based Correlation</a>.
+      </p>
+
+    </section>
+
+    <section class="informative">
       <h3>Verifier Caching</h3>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1139,8 +1139,9 @@ that have received a credential from the same geographic region.
       <p>
 There are a number of global identifiers used in a status list entry, defined in
 Section [[[#bitstringstatuslistentry]]], that can be used across [=verifiers=]
-to correlate [=subjects=]. Some of these properties include `id`,
-`statusListIndex`, and `statusListCredential`.
+to correlate [=subjects=]. Some of the properties that can 
+express these values are `id`, `statusListIndex`, and 
+`statusListCredential`.
       </p>
 
       <p>
@@ -1156,7 +1157,7 @@ When global identifiers are used in [=presentations=] that use
 [=selective disclosure=] or [=unlinkable disclosure=], they can violate privacy
 expectations. [=Issuers=] are urged to enable status information to be
 selectively disclosable/concealable when a particular [=verifiable credential=]
-is expected to be disclosed in a way that doesn't need correlation, such as when
+is expected to be disclosed in a way that does not need correlation, such as when
 proving that an individual is above a certain age. [=Verifiers=] can require
 that status information be revealed in situations that require them to know the
 current status of a credential, and the holder might then consent or refuse to
@@ -1167,7 +1168,7 @@ prevent correlation, unless it is required for or by a particular exchange.
 
       <p>
 For information on other types of potential correlation,
-readers are urged to digest the Privacy Considerations section of the
+readers are urged to study the Privacy Considerations section of the
 [[[VC-DATA-MODEL-2.0]]] specification, particularly the subsections on
 <a data-cite="VC-DATA-MODEL-2.0#identifier-based-correlation">
 Identifier-Based Correlation</a>,


### PR DESCRIPTION
This PR is an attempt to address issue #142 and #147 by providing some guidance on when it's appropriate to use status lists that contain globally unique identifiers and when status lists should be selectively disclosable.

/cc @zoracon


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/160.html" title="Last updated on Apr 6, 2024, 6:11 PM UTC (ed3f86f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/160/065e536...ed3f86f.html" title="Last updated on Apr 6, 2024, 6:11 PM UTC (ed3f86f)">Diff</a>