### PR TITLE
Add suggestion on how malicious issuers can be detected.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1174,10 +1174,12 @@ secure communication channel between the [=issuer=] and the [=verifier=].
       </p>
       <p>
 A malicious [=issuer=] might intentionally attack group privacy by creating a
-unique status list per issued credential, in order to establish a one-to-one
+unique status list for each issued credential, in order to establish a one-to-one
 mapping to track when a [=verifier=] processes each mapped credential. Similarly,
 they could establish a one-to-one mapping by using a different
-cryptographic key for each credential issued that is tracked by a given status list.
+cryptographic key for each issued credential that is tracked by a given status list.
+      </p>
+      <p>
 This sort of collusion can be detected by [=holder=] software that serves
 multiple [=holders=] (e.g., a [=holder=] app that runs on a server) if it
 has, for example, an opt-in process that finds that some global identifier(s) 

--- a/index.html
+++ b/index.html
@@ -1181,7 +1181,8 @@ cryptographic key for each credential issued that is tracked by a given status l
 This sort of collusion can be detected by [=holder=] software that serves
 multiple [=holders=] (e.g., a [=holder=] app that runs on a server) if it
 has, for example, an opt-in process that finds that some global identifier(s) 
-used within a [=verifiable credential=] are shared by other credentials.
+used within a [=verifiable credential=] are not adequately shared by other
+credentials.
 [=Holders=] could then be warned when presenting a [=verifiable credential=]
 that contains some global identifier(s) that are unique to that credential.
 Such an opt-in service could represent some additional privacy concerns;

--- a/index.html
+++ b/index.html
@@ -1167,15 +1167,22 @@ benefits can only be realized when issuers and verifiers intend to avoid
 tracking or sharing the presentation of particular credentials.
       </p>
       <p>
-A malicious [=issuer=] might intentionally attack group privacy by creating a
-unique status list per credential issued in order to establish a one-to-one mapping to track
-when a [=verifier=] processes a specific credential. Similarly, they could establish
-another a one-to-one mapping by using a different cryptographic key for every credential
-issued that is tracked in a status list.
+A malicious [=verifier=] might intentionally attack group privacy by sharing
+information from presented credentials with a malicious [=issuer=]. This
+sort of collusion is difficult to detect as it is typically performed in a
+secure communication channel between the [=issuer=] and the [=verifier=].
       </p>
       <p>
-A malicious [=verifier=] might intentionally attack group privacy by sharing
-information from presented credentials with a malicious [=issuer=].
+A malicious [=issuer=] might intentionally attack group privacy by creating a
+unique status list per credential issued in order to establish a one-to-one
+mapping to track when a [=verifier=] processes a specific credential. Similarly,
+they could establish another a one-to-one mapping by using a different
+cryptographic key for every credential issued that is tracked in a status list.
+This sort of collusion can be detected by [=holder=] software by detecting
+if the global identifiers used within a [=verifiable credential=] are shared
+by other credentials. [=Holders=] could then be warned when presenting a
+[=verifiable credential=] that contains global identifiers that are unique to
+that credential.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -1169,20 +1169,25 @@ tracking or sharing the presentation of particular credentials.
       <p>
 A malicious [=verifier=] might intentionally attack group privacy by sharing
 information from presented credentials with a malicious [=issuer=]. This
-sort of collusion is difficult to detect as it is typically performed in a
+sort of collusion is difficult to detect as it is typically performed via a
 secure communication channel between the [=issuer=] and the [=verifier=].
       </p>
       <p>
 A malicious [=issuer=] might intentionally attack group privacy by creating a
-unique status list per credential issued in order to establish a one-to-one
-mapping to track when a [=verifier=] processes a specific credential. Similarly,
-they could establish another a one-to-one mapping by using a different
-cryptographic key for every credential issued that is tracked in a status list.
-This sort of collusion can be detected by [=holder=] software by detecting
-if the global identifiers used within a [=verifiable credential=] are shared
-by other credentials. [=Holders=] could then be warned when presenting a
-[=verifiable credential=] that contains global identifiers that are unique to
-that credential.
+unique status list per issued credential, in order to establish a one-to-one
+mapping to track when a [=verifier=] processes each mapped credential. Similarly,
+they could establish a one-to-one mapping by using a different
+cryptographic key for each credential issued that is tracked by a given status list.
+This sort of collusion can be detected by [=holder=] software that serves
+multiple [=holders=] (e.g., a [=holder=] app that runs on a server) if it
+has, for example, an opt-in process that finds that some global identifier(s) 
+used within a [=verifiable credential=] are shared by other credentials.
+[=Holders=] could then be warned when presenting a [=verifiable credential=]
+that contains some global identifier(s) that are unique to that credential.
+Such an opt-in service could represent some additional privacy concerns;
+whether this potential exposure via the [=holder=] software is justified by
+the awareness of possible global identifier correlation can only be evaluated
+by the users of such a system.
       </p>
     </section>
 


### PR DESCRIPTION
This PR attempts to address issue #143 by adding guidance on how holder software can detect malicious issuers that inject tracking identifiers into their credentials.

/cc @zoracon


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/161.html" title="Last updated on Apr 16, 2024, 7:50 PM UTC (7fb0dd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/161/065e536...7fb0dd2.html" title="Last updated on Apr 16, 2024, 7:50 PM UTC (7fb0dd2)">Diff</a>