### PR TITLE
Added a reference to optional features in SOTD

### DIFF
--- a/CR/2024-05-09/index.html
+++ b/CR/2024-05-09/index.html
@@ -839,7 +839,7 @@ suspension or revocation of Verifiable Credentials through use of bitstrings.
 The Working Group is actively seeking implementation feedback for this
 specification. In order to exit the Candidate Recommendation phase, the
 Working Group has set the requirement of at least two independent
-implementations for each mandatory feature in the specification. For details
+implementations for each mandatory or optional feature in the specification. For details
 on the conformance testing process, see the
 <a href="https://w3c.github.io/vc-bitstring-status-list-test-suite/">
 implementation report</a>.

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@ suspension or revocation of Verifiable Credentials through use of bitstrings.
 The Working Group is actively seeking implementation feedback for this
 specification. In order to exit the Candidate Recommendation phase, the
 Working Group has set the requirement of at least two independent
-implementations for each mandatory feature in the specification. For details
+implementations for each mandatory or optional feature in the specification. For details
 on the conformance testing process, see the
 <a href="https://w3c.github.io/vc-bitstring-status-list-test-suite/">
 implementation report</a>.


### PR DESCRIPTION
Changing the core index.html and the CR dump to answer PlH's request in https://github.com/w3c/transitions/issues/603#issuecomment-2092978449.

If this PR is correct spec-wise (@msporny ?) and is what PlH is waiting for (@plehegar ?) then, after merging, we may still get an approval for a publication next Thursday _and_ I can take care of it before I disappear for my break...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/170.html" title="Last updated on May 3, 2024, 1:40 PM UTC (e58098d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/170/d3b6981...e58098d.html" title="Last updated on May 3, 2024, 1:40 PM UTC (e58098d)">Diff</a>