### PR TITLE
Specify to use multibase representation of the base64url algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1184,7 +1184,7 @@ times the `statusSize`.
         <li>
 Generate a |compressed bitstring| by using the GZIP
 compression algorithm [[RFC1952]] on the |bitstring|
-and then base64url-encoding (with no padding) [[RFC4648]] the result.
+and then Multibase-encode the result using base64url (with no padding) [RFC4648].
         </li>
         <li>
 Return the |compressed bitstring|.
@@ -1209,7 +1209,7 @@ bitstring.
         </li>
         <li>
 Generate an |uncompressed bitstring| by using the
-base64url-decoding (with no padding) [[RFC4648]] algorithm on the
+Multibase-decode algorithm on the
 |compressed bitstring| and then expanding the output using
 the GZIP decompression algorithm [[RFC1952]].
         </li>

--- a/index.html
+++ b/index.html
@@ -1184,7 +1184,7 @@ times the `statusSize`.
         <li>
 Generate a |compressed bitstring| by using the GZIP
 compression algorithm [[RFC1952]] on the |bitstring|
-and then Multibase-encode the result using base64url (with no padding) [RFC4648].
+and then <a data-cite="?CONTROLLER-DOCUMENT#multibase-0">Multibase-encode</a> the result using base64url (with no padding).
         </li>
         <li>
 Return the |compressed bitstring|.
@@ -1209,7 +1209,7 @@ bitstring.
         </li>
         <li>
 Generate an |uncompressed bitstring| by using the
-Multibase-decode algorithm on the
+<a data-cite="?CONTROLLER-DOCUMENT#multibase-0">Multibase-decode</a> algorithm on the
 |compressed bitstring| and then expanding the output using
 the GZIP decompression algorithm [[RFC1952]].
         </li>


### PR DESCRIPTION
This adds specific instructions on the generate/expand bitstring algorithms to use multibase base64url instead of just base64url to be consistent with the data model section.

addresses #178


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/pull/179.html" title="Last updated on Nov 18, 2024, 2:01 AM UTC (d7146a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/179/47e1900...d7146a4.html" title="Last updated on Nov 18, 2024, 2:01 AM UTC (d7146a4)">Diff</a>