### PR TITLE
Clarify that TTL is optional and doesn't override validity.

### DIFF
--- a/index.html
+++ b/index.html
@@ -920,13 +920,13 @@ encoding can be found in Section <a href="#bitstring-encoding"></a>.
             <tr>
               <td id="ttl">credentialSubject.ttl</td>
               <td>
-The `ttl` indicates the "time to live" in milliseconds. This property MAY be
-present. If not present, implementers MUST use a value of `300000` for this
-property.  A verifier MUST NOT use a cached `BitstringStatusListCredential` that
-was cached for more than the `ttl` duration prior to the start of verification
-operation on a [=verifiable credential=]. Implementations that publish the
-status list SHOULD align any protocol-specific caching information, such as the
-HTTP `Cache-Control` header, with the value in this field.
+The `ttl` is an OPTIONAL property that indicates the "time to live" in
+milliseconds before a refresh SHOULD be attempted. If not present, no default
+value is assumed. The value does not override or replace the
+<a data-cite="VC-DATA-MODEL-2.0#validity-period">validity period</a>
+of the `BitstringStatusList`. Implementations that publish the status list
+SHOULD align any protocol-specific caching information, such as the HTTP
+`Cache-Control` header, with the value in this field.
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
This PR is an attempt to address issue #174 by clarifying that TTL is optional and doesn't override the credential's validity period.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 24, 2024, 11:22 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
Timed out after waiting 30000ms
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-bitstring-status-list%23186.)._
</details>
