### PR TITLE
Provide guidance on choosing validity periods for status lists.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1682,12 +1682,13 @@ be 0, and the last index will be 131,071.
       <h3>Validity Periods</h3>
 
       <p>
-The <a data-cite="?VC-DATA-MODEL-2.0#validity-period">validity period</a> of a
-status list is dependent on a variety of factors including:
+The <a data-cite="?VC-DATA-MODEL-2.0#validity-period">validity period</a> that
+an issuer might choose to express in a status list is dependent on a variety of
+factors including:
       </p>
       <ul>
         <li>
-How often do status values change? In real-time? Daily? Weekly? Monthly?
+How often do status values change? In real-time? Daily? Weekly? Monthly? Other?
         </li>
         <li>
 Is there a regulatory requirement that compels an [=issuer=] to notify a
@@ -1698,23 +1699,23 @@ Is there a period of time after which an [=issuer=] would incur reputational
 damage by not notifying a [=verifier=] of a status change?
         </li>
         <li>
-Is there an expectation by a [=verifier=] to not accept a
-[=verifiable credential=] with a status list that does not expire for an
-excessive period of time?
+Is there any expectation that a [=verifier=] will not accept a
+[=verifiable credential=] with a status list that does not expire for a
+period of time it deems excessive?
         </li>
         <li>
-Is there an excessive network bandwidth or computing burden placed upon an
-[=issuer=] or a [=verifier=] if a validity period is too short for a
-status list?
+Will a short validity period for a status list cause a significant network
+bandwidth or computing burden for an [=issuer=] or a [=verifier=]? Might
+this burden be mitigated by a longer validity period?
         </li>
       </ul>
 
       <p>
-Since these factors vary based on ecosystem and credential type, there is no
-minimum or maximum validity period that is suggested for a status list.
-[=Issuers=] will need to take various considerations into account that are
-specific to their [=verifiable credential=] types and pick validity periods that
-will strike the right balance in their ecosystem.
+Since these factors vary with the ecosystem and credential type, there is no
+minimum or maximum validity period that is suggested for all status lists.
+[=Issuers=] will need to consider various factors that are specific to their
+[=verifiable credential=] types and choose validity periods that will strike
+the right balance in their ecosystem.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -1687,20 +1687,25 @@ status list is dependent on a variety of factors including:
       </p>
       <ul>
         <li>
+How often do status values change? In real-time? Daily? Weekly? Monthly?
+        </li>
+        <li>
 Is there a regulatory requirement that compels an [=issuer=] to notify a
-[=verifier=] that the status of a [=verifiable credential's=] has changed?
+[=verifier=] that the status of a [=verifiable credential=] has changed?
         </li>
         <li>
 Is there a period of time after which an [=issuer=] would incur reputational
 damage by not notifying a [=verifier=] of a status change?
         </li>
         <li>
+Is there an expectation by a [=verifier=] to not accept a
+[=verifiable credential=] with a status list that does not expire for an
+excessive period of time?
+        </li>
+        <li>
 Is there an excessive network bandwidth or computing burden placed upon an
 [=issuer=] or a [=verifier=] if a validity period is too short for a
 status list?
-        </li>
-        <li>
-How often do status values change?
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -1678,6 +1678,38 @@ be 0, and the last index will be 131,071.
       </p>
     </section>
 
+    <section class="informative">
+      <h3>Validity Periods</h3>
+
+      <p>
+The <a data-cite="?VC-DATA-MODEL-2.0#validity-period">validity period</a> of a
+status list is dependent on a variety of factors including:
+      </p>
+      <ul>
+        <li>
+Is there a regulatory requirement that compels an [=issuer=] to notify a
+[=verifier=] that the status of a [=verifiable credential's=] has changed?
+        </li>
+        <li>
+Is there a period of time after which an [=issuer=] would incur reputational
+damage by not notifying a [=verifier=] of a status change?
+        </li>
+        <li>
+Is there an excessive network bandwidth or computing burden placed upon an
+[=issuer=] or a [=verifier=] if a validity period is too short for a
+status list?
+        </li>
+        <li>
+How often do status values change?
+        </li>
+      </ul>
+
+      <p>
+[=Issuers=] will need to take various considerations into account that are
+specific to their [=verifiable credential=] types and pick validity periods that
+will strike the right balance in their ecosystem.
+      </p>
+    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -1705,6 +1705,8 @@ How often do status values change?
       </ul>
 
       <p>
+Since these factors vary based on ecosystem and credential type, there is no
+minimum or maximum validity period that is suggested for a status list.
 [=Issuers=] will need to take various considerations into account that are
 specific to their [=verifiable credential=] types and pick validity periods that
 will strike the right balance in their ecosystem.


### PR DESCRIPTION
This PR is an attempt to address issue #48 by providing guidance on how to choose validity periods for status lists.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 2, 2024, 7:00 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
Protocol error (Runtime.callFunctionOn): Promise was collected
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-bitstring-status-list%23190.)._
</details>
