### PR TITLE
Added the context references to the vocabulary.yml file

### DIFF
--- a/vocab/vocabulary.yml
+++ b/vocab/vocabulary.yml
@@ -1,7 +1,7 @@
 vocab:
   - id: cs
     value: https://www.w3.org/ns/credentials/status#
-    context: https://www.w3.org/ns/credentials/v2
+    context: https://www.w3.org/ns/credentials/status/v1
 
 prefix:
   - id: cred
@@ -23,17 +23,21 @@ ontology:
 class:
   - id: BitstringStatusList
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslist
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: BitstringStatusListEntry
     upper_value: cred:CredentialStatus
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistentry
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: BitstringStatusListCredential
     upper_value: cred:VerifiableCredential
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: BitstringStatusMessage
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusMessage
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
 property:
   - id: statusPurpose
@@ -42,53 +46,63 @@ property:
       - cs:BitstringStatusList
       - cs:BitstringStatusListEntry
     range: xsd:string
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: statusListIndex
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusListIndex
     domain: cs:BitstringStatusListEntry
     range: xsd:string
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: statusListCredential
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusListCredential
     domain: cs:BitstringStatusListEntry
     range: cs:BitstringStatusListCredential
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: encodedList
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#encodedList
     domain: cs:BitstringStatusList
     range: sec:multibase
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: ttl
     label: Time to live in milliseconds
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#ttl
     domain: cs:BitstringStatusList
     range: xsd:string
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: statusSize
     label: Bitstring entry size in bits
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusSize
     domain: cs:BitstringStatusList
     range: xsd:positiveInteger
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: statusMessage
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusMessage
     domain: cs:BitstringStatusList
     range: cs:BitstringStatusMessage
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: status
     label: Hexadecimal value of a status message
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#status
     range: xsd:string
     domain: cs:BitstringStatusMessage
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: message
     label: Human-readable message of a status value
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#message
     range: xsd:string
     domain: cs:BitstringStatusMessage
+    context: [vocab,https://www.w3.org/ns/credentials/v2]
 
   - id: statusReference
     label: Reference documentation for status messages
     defined_by: https://www.w3.org/TR/vc-bitstring-status-list/#statusReference
     domain: cs:BitstringStatusList
     range: URL
+    context: [vocab,https://www.w3.org/ns/credentials/v2]


### PR DESCRIPTION
This means that the references to the relevant context files will appear for each term. (See the [di vocabulary description](https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html#context-files) as a reference to what this means).