### PR TITLE
added note clarifying that credentialSubject.id is not used 

### DIFF
--- a/index.html
+++ b/index.html
@@ -734,7 +734,7 @@ credential.
         </p>
 
         <p class="note">
-It is important to note that the statusListIndex is the only link between
+It is important to note that `statusListIndex` is the only link between
 the [=Verifiable credential=] and its status in the list. The
 ```credentialSubject.id``` is not used when checking status. 
         </p>

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@ credential.
 
         <p class="note">
 It is important to note that `statusListIndex` is the only link between
-the [=Verifiable credential=] and its status in the list. The
+the [=verifiable credential=] and its status in the list. The
 ```credentialSubject.id``` is not used when checking status. 
         </p>
 

--- a/index.html
+++ b/index.html
@@ -735,8 +735,9 @@ credential.
 
         <p class="note">
 It is important to note that `statusListIndex` is the only link between
-the [=verifiable credential=] and its status in the list. The
-```credentialSubject.id``` is not used when checking status. 
+the [=verifiable credential=] and its status in the list. Other
+properties such as `credentialSubject.id` are not used for
+this purpose.
         </p>
 
         <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -733,6 +733,12 @@ could then be discoverable by a [=verifier=] that later receives that
 credential.
         </p>
 
+        <p class="note">
+It is important to note that the statusListIndex is the only link between
+the [=Verifiable credential=] and its status in the list. The
+```credentialSubject.id``` is not used when checking status. 
+        </p>
+
         <pre class="example nohighlight"
              title="Example StatusListCredential using more complex entries">
 {


### PR DESCRIPTION
to look up the entry in the status list.

Addresses #184


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/LegReq/vc-bitstring-status-list/pull/196.html" title="Last updated on Jan 9, 2025, 4:41 PM UTC (30edd72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-bitstring-status-list/196/2064063...LegReq:30edd72.html" title="Last updated on Jan 9, 2025, 4:41 PM UTC (30edd72)">Diff</a>